### PR TITLE
V1.2 list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListPrescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListPrescriptionCommand.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.ModelPrescription.PREDICATE_SHOW_ALL_PRESCRIPTIONS;
+
+import seedu.address.model.ModelPrescription;
+
+/**
+ * Lists all prescriptions stored to the user.
+ */
+public class ListPrescriptionCommand extends CommandPrescription {
+
+    public static final String COMMAND_WORD = "list";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all prescriptions stored.\n"
+        + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "Listed all prescriptions";
+
+    @Override
+    public CommandResult execute(ModelPrescription model) {
+        requireNonNull(model);
+        model.updateFilteredPrescriptionList(PREDICATE_SHOW_ALL_PRESCRIPTIONS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListPrescriptionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListPrescriptionCommand.java
@@ -13,7 +13,7 @@ public class ListPrescriptionCommand extends CommandPrescription {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all prescriptions stored.\n"
-        + "Example: " + COMMAND_WORD;
+            + "Example: " + COMMAND_WORD;
 
     public static final String MESSAGE_SUCCESS = "Listed all prescriptions";
 

--- a/src/main/java/seedu/address/logic/parser/ListPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListPrescriptionCommandParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.MessagesPrescription.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ListPrescriptionCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new AddCommand object
+ */
+public class ListPrescriptionCommandParser implements ParserPrescription<ListPrescriptionCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddCommand
+     * and returns an AddCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListPrescriptionCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+            ArgumentTokenizer.tokenize(args);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                ListPrescriptionCommand.MESSAGE_USAGE));
+        }
+
+        return new ListPrescriptionCommand();
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ListPrescriptionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListPrescriptionCommandParser.java
@@ -8,13 +8,13 @@ import seedu.address.logic.commands.ListPrescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new ListPrescriptionCommand object
  */
 public class ListPrescriptionCommandParser implements ParserPrescription<ListPrescriptionCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the ListPrescriptionCommand
+     * and returns a ListPrescriptionCommand object for execution.
      *
      * @throws ParseException if the user input does not conform the expected format
      */

--- a/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
+++ b/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddPrescriptionCommand;
 import seedu.address.logic.commands.CommandPrescription;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListPrescriptionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -49,6 +50,9 @@ public class PrescriptionListParser {
 
         case AddPrescriptionCommand.COMMAND_WORD:
             return new AddPrescriptionCommandParser().parse(arguments);
+
+        case ListPrescriptionCommand.COMMAND_WORD:
+            return new ListPrescriptionCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/ui/PrescriptionCard.java
+++ b/src/main/java/seedu/address/ui/PrescriptionCard.java
@@ -47,6 +47,20 @@ public class PrescriptionCard extends UiPart<Region> {
     @FXML
     private Label note;
 
+    private String dosageHeader = "Dosage: ";
+
+    private String frequencyHeader = "Frequency: ";
+
+    private String startDateHeader = "Start date: ";
+
+    private String endDateHeader = "End date: ";
+
+    private String expiryDateHeader = "Expiry date: ";
+
+    private String totalStockHeader = "Total stock: ";
+
+    private String noteHeader = "Note: ";
+
     /**
      * Creates a {@code PrescriptionCode} with the given {@code Prescription} and index to display.
      */
@@ -55,13 +69,13 @@ public class PrescriptionCard extends UiPart<Region> {
         this.prescription = prescription;
         id.setText(displayedIndex + ". ");
         name.setText(prescription.getName().fullName);
-        dosage.setText(prescription.getDosage().fullDosage);
-        frequency.setText(prescription.getFrequency().fullFrequency);
-        startDate.setText(prescription.getStartDate().fullDate);
-        endDate.setText(prescription.getEndDate().fullDate);
-        expiryDate.setText(prescription.getExpiryDate().fullDate);
-        totalStock.setText(prescription.getTotalStock().fullStock);
-        note.setText(prescription.getNote().fullNote);
+        dosage.setText(dosageHeader + prescription.getDosage().fullDosage);
+        frequency.setText(frequencyHeader + prescription.getFrequency().fullFrequency);
+        startDate.setText(startDateHeader + prescription.getStartDate().fullDate);
+        endDate.setText(endDateHeader + prescription.getEndDate().fullDate);
+        expiryDate.setText(expiryDateHeader + prescription.getExpiryDate().fullDate);
+        totalStock.setText(totalStockHeader + prescription.getTotalStock().fullStock);
+        note.setText(noteHeader + prescription.getNote().fullNote);
         // prescription.getTags().stream()
         //         .sorted(Comparator.comparing(tag -> tag.tagName))
         //         .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));


### PR DESCRIPTION
Added list command. Did it slightly different from AB3 in that I mandated `list` strictly.

Example: `list asdasdasd` works for AB3 but throws an error in BayMeds.

Also added **temporary** labels to the display so that its easier for us to see. I'll make them nicer (maybe color block it) in the future.

Understandably this addition amounts to naught. The repo is very messy atm so in the near future I'll work on the test codes and GUI if time permits so that we can remove the AB3 clutter and pass code cov.