### PR TITLE
fix jsonadapted typo

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPrescription.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPrescription.java
@@ -120,7 +120,7 @@ class JsonAdaptedPrescription {
         if (endDate == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName()));
         }
-        if (!Date.isValidDate(expiryDate)) {
+        if (!Date.isValidDate(endDate)) {
             throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
         }
         final Date modelEndDate = new Date(endDate);


### PR DESCRIPTION
I'm currently writing the test code for BayMeds. Found this bug.