### PR TITLE
Add Edit Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.Model;
 import seedu.address.model.prescription.Prescription;
 
 /**
- * Adds a person to the address book.
+ * Adds a prescription to the prescription list.
  */
 public class AddCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.Model;
 import seedu.address.model.prescription.Prescription;
 
 /**
- * Adds a person to the address book.
+ * Deletes a prescription from prescription list.
  */
 public class DeleteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,0 +1,265 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONSUMPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREQUENCY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_STOCK;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PRESCRIPTIONS;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.prescription.ConsumptionCount;
+import seedu.address.model.prescription.Date;
+import seedu.address.model.prescription.Dosage;
+import seedu.address.model.prescription.Frequency;
+import seedu.address.model.prescription.Name;
+import seedu.address.model.prescription.Note;
+import seedu.address.model.prescription.Prescription;
+import seedu.address.model.prescription.Stock;
+
+
+/**
+ * Edits the details of an existing prescription in prescription list.
+ */
+public class EditCommand extends Command {
+    public static final String COMMAND_WORD = "edit";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the prescription identified "
+            + "by the index number used in the displayed prescription list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_DOSAGE + "DOSAGE] "
+            + "[" + PREFIX_FREQUENCY + "FREQUENCY] "
+            + "[" + PREFIX_START_DATE + "START DATE] "
+            + "[" + PREFIX_END_DATE + "END DATE] "
+            + "[" + PREFIX_EXPIRY_DATE + "EXPIRY DATE] "
+            + "[" + PREFIX_TOTAL_STOCK + "TOTAL STOCK] "
+            + "[" + PREFIX_CONSUMPTION + "CONSUMPTION] "
+            + "[" + PREFIX_NOTE + "NOTE]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_NAME + "Aspirin "
+            + PREFIX_NOTE + "Take after meal";
+    public static final String MESSAGE_EDIT_PRESCRIPTION_SUCCESS = "Edited Prescription: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PRESCRIPTION = "This prescription already exists in the address book.";
+
+    private final Index index;
+    private final EditPrescriptionDescriptor editPrescriptionDescriptor;
+    /**
+     * Creates an EditCommand to edit the specified {@code Prescription}
+     */
+    public EditCommand(Index index, EditPrescriptionDescriptor editPrescriptionDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editPrescriptionDescriptor);
+
+        this.index = index;
+        this.editPrescriptionDescriptor = new EditPrescriptionDescriptor(editPrescriptionDescriptor);
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Prescription> lastShownList = model.getFilteredPrescriptionList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX);
+        }
+
+        Prescription prescriptionToEdit = lastShownList.get(index.getZeroBased());
+        Prescription editedPrescription = createEditedPrescription(prescriptionToEdit, editPrescriptionDescriptor);
+
+        if (!prescriptionToEdit.isSamePrescription(editedPrescription) && model.hasPrescription(editedPrescription)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PRESCRIPTION);
+        }
+
+        model.setPrescription(prescriptionToEdit, editedPrescription);
+        model.updateFilteredPrescriptionList(PREDICATE_SHOW_ALL_PRESCRIPTIONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_PRESCRIPTION_SUCCESS, editedPrescription));
+    }
+
+    private static Prescription createEditedPrescription(Prescription prescriptionToEdit,
+                                                         EditPrescriptionDescriptor editPrescriptionDescriptor) {
+        assert prescriptionToEdit != null;
+
+        Name updatedName = editPrescriptionDescriptor.getName().orElse(prescriptionToEdit.getName());
+        Dosage updatedDosage = editPrescriptionDescriptor.getDosage().orElse(prescriptionToEdit.getDosage());
+        Frequency updatedFrequency = editPrescriptionDescriptor.getFrequency()
+                .orElse(prescriptionToEdit.getFrequency());
+        Date updatedStartDate = editPrescriptionDescriptor.getStartDate().orElse(prescriptionToEdit.getStartDate());
+        Date updatedEndDate = editPrescriptionDescriptor.getEndDate().orElse(prescriptionToEdit.getEndDate());
+        Date updatedExpiryDate = editPrescriptionDescriptor.getExpiryDate().orElse(prescriptionToEdit.getExpiryDate());
+        Stock updatedTotalStock = editPrescriptionDescriptor.getTotalStock().orElse(prescriptionToEdit.getTotalStock());
+        ConsumptionCount updatedConsumptionCount = editPrescriptionDescriptor.getConsumptionCount()
+                .orElse(prescriptionToEdit.getConsumptionCount());
+        Note updatedNote = editPrescriptionDescriptor.getNote().orElse(prescriptionToEdit.getNote());
+
+        return new Prescription(updatedName, updatedDosage, updatedFrequency, updatedStartDate, updatedEndDate,
+                updatedExpiryDate, updatedTotalStock, updatedConsumptionCount, updatedNote);
+    }
+
+    /**
+     * Creates and returns a {@code Prescription} with the details of {@code prescriptionToEdit}
+     * edited with {@code editPrescriptionDescriptor}.
+     */
+    public static class EditPrescriptionDescriptor {
+        private Name name;
+        private Dosage dosage;
+        private Frequency frequency;
+        private Date startDate;
+        private Date endDate;
+        private Date expiryDate;
+        private Stock totalStock;
+        private ConsumptionCount consumptionCount;
+        private Note note;
+        public EditPrescriptionDescriptor() {}
+
+        /**
+         * Creates an EditPrescriptionDescriptor with the details of {@code prescriptionToEdit}
+         */
+        public EditPrescriptionDescriptor(EditPrescriptionDescriptor toCopy) {
+            setName(toCopy.name);
+            setDosage(toCopy.dosage);
+            setFrequency(toCopy.frequency);
+            setStartDate(toCopy.startDate);
+            setEndDate(toCopy.endDate);
+            setExpiryDate(toCopy.expiryDate);
+            setTotalStock(toCopy.totalStock);
+            setConsumptionCount(toCopy.consumptionCount);
+            setNote(toCopy.note);
+        }
+
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(
+                    name, dosage, frequency, startDate, endDate, expiryDate, totalStock, consumptionCount, note);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setDosage(Dosage dosage) {
+            this.dosage = dosage;
+        }
+
+        public Optional<Dosage> getDosage() {
+            return Optional.ofNullable(dosage);
+        }
+
+        public void setFrequency(Frequency frequency) {
+            this.frequency = frequency;
+        }
+
+        public Optional<Frequency> getFrequency() {
+            return Optional.ofNullable(frequency);
+        }
+
+        public void setStartDate(Date startDate) {
+            this.startDate = startDate;
+        }
+
+        public Optional<Date> getStartDate() {
+            return Optional.ofNullable(startDate);
+        }
+
+        public void setEndDate(Date endDate) {
+            this.endDate = endDate;
+        }
+
+        public Optional<Date> getEndDate() {
+            return Optional.ofNullable(endDate);
+        }
+
+        public void setExpiryDate(Date expiryDate) {
+            this.expiryDate = expiryDate;
+        }
+
+        public Optional<Date> getExpiryDate() {
+            return Optional.ofNullable(expiryDate);
+        }
+
+        public void setTotalStock(Stock totalStock) {
+            this.totalStock = totalStock;
+        }
+
+        public Optional<Stock> getTotalStock() {
+            return Optional.ofNullable(totalStock);
+        }
+
+        public void setNote(Note note) {
+            this.note = note;
+        }
+
+        public Optional<Note> getNote() {
+            return Optional.ofNullable(note);
+        }
+
+        public void setConsumptionCount(ConsumptionCount consumptionCount) {
+            this.consumptionCount = consumptionCount;
+        }
+
+        public Optional<ConsumptionCount> getConsumptionCount() {
+            return Optional.ofNullable(consumptionCount);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            //instanceof handles nulls
+            if (!(other instanceof EditPrescriptionDescriptor)) {
+                return false;
+            }
+
+            EditPrescriptionDescriptor otherEditPrescriptionDescriptor = (EditPrescriptionDescriptor) other;
+            return Objects.equals(name, otherEditPrescriptionDescriptor.name)
+                    && Objects.equals(dosage, otherEditPrescriptionDescriptor.dosage)
+                    && Objects.equals(frequency, otherEditPrescriptionDescriptor.frequency)
+                    && Objects.equals(startDate, otherEditPrescriptionDescriptor.startDate)
+                    && Objects.equals(endDate, otherEditPrescriptionDescriptor.endDate)
+                    && Objects.equals(expiryDate, otherEditPrescriptionDescriptor.expiryDate)
+                    && Objects.equals(totalStock, otherEditPrescriptionDescriptor.totalStock)
+                    && Objects.equals(consumptionCount, otherEditPrescriptionDescriptor.consumptionCount)
+                    && Objects.equals(note, otherEditPrescriptionDescriptor.note);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("name", name)
+                    .add("dosage", dosage)
+                    .add("frequency", frequency)
+                    .add("startDate", startDate)
+                    .add("endDate", endDate)
+                    .add("expiryDate", expiryDate)
+                    .add("totalStock", totalStock)
+                    .add("consumptionCount", consumptionCount)
+                    .add("note", note)
+                    .toString();
+        }
+
+    }
+}
+
+

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -90,7 +90,7 @@ public class EditCommand extends Command {
 
         model.setPrescription(prescriptionToEdit, editedPrescription);
         model.updateFilteredPrescriptionList(PREDICATE_SHOW_ALL_PRESCRIPTIONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PRESCRIPTION_SUCCESS, editedPrescription));
+        return new CommandResult(String.format(MESSAGE_EDIT_PRESCRIPTION_SUCCESS, Messages.format(editedPrescription)));
     }
 
     private static Prescription createEditedPrescription(Prescription prescriptionToEdit,

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.EditCommand.EditPrescriptionDescriptor;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONSUMPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FREQUENCY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_STOCK;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditPrescriptionCommand object
+ */
+public class EditCommandParser implements Parser<EditCommand> {
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public EditCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_DOSAGE, PREFIX_FREQUENCY, PREFIX_START_DATE,
+                        PREFIX_END_DATE, PREFIX_EXPIRY_DATE, PREFIX_TOTAL_STOCK, PREFIX_CONSUMPTION, PREFIX_NOTE);
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE), pe);
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_DOSAGE, PREFIX_FREQUENCY, PREFIX_START_DATE,
+                PREFIX_END_DATE, PREFIX_EXPIRY_DATE, PREFIX_TOTAL_STOCK, PREFIX_CONSUMPTION, PREFIX_NOTE);
+
+        EditPrescriptionDescriptor editPrescriptionDescriptor = new EditPrescriptionDescriptor();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editPrescriptionDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_DOSAGE).isPresent()) {
+            editPrescriptionDescriptor.setDosage(ParserUtil.parseDosage(argMultimap.getValue(PREFIX_DOSAGE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_FREQUENCY).isPresent()) {
+            editPrescriptionDescriptor.setFrequency(
+                    ParserUtil.parseFrequency(argMultimap.getValue(PREFIX_FREQUENCY).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_START_DATE).isPresent()) {
+            editPrescriptionDescriptor.setStartDate(
+                    ParserUtil.parseStartDate(argMultimap.getValue(PREFIX_START_DATE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_END_DATE).isPresent()) {
+            editPrescriptionDescriptor.setEndDate(ParserUtil.parseEndDate(argMultimap.getValue(PREFIX_END_DATE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_EXPIRY_DATE).isPresent()) {
+            editPrescriptionDescriptor.setExpiryDate(
+                    ParserUtil.parseExpiryDate(argMultimap.getValue(PREFIX_EXPIRY_DATE).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_TOTAL_STOCK).isPresent()) {
+            editPrescriptionDescriptor.setTotalStock(
+                    ParserUtil.parseTotalStock(argMultimap.getValue(PREFIX_TOTAL_STOCK).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_CONSUMPTION).isPresent()) {
+            editPrescriptionDescriptor.setConsumptionCount(
+                    ParserUtil.parseConsumptionCount(argMultimap.getValue(PREFIX_CONSUMPTION).get()));
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE).isPresent()) {
+            editPrescriptionDescriptor.setNote(ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get()));
+        }
+
+        if (!editPrescriptionDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditCommand(index, editPrescriptionDescriptor);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.prescription.ConsumptionCount;
 import seedu.address.model.prescription.Date;
 import seedu.address.model.prescription.Dosage;
 import seedu.address.model.prescription.Frequency;
@@ -139,6 +140,21 @@ public class ParserUtil {
             throw new ParseException(Stock.MESSAGE_CONSTRAINTS);
         }
         return new Stock(trimmedTotalStock);
+    }
+
+    /**
+     * Parses a {@code String ConsumptionCount} into a {@code ConsumptionCount}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code consumptionCount} is invalid.
+     */
+    public static ConsumptionCount parseConsumptionCount(String consumptionCount) throws ParseException {
+        requireNonNull(consumptionCount);
+        String trimmedConsumptionCount = consumptionCount.trim();
+        if (!ConsumptionCount.isValidConsumptionCount(trimmedConsumptionCount)) {
+            throw new ParseException(ConsumptionCount.MESSAGE_CONSTRAINTS);
+        }
+        return new ConsumptionCount(trimmedConsumptionCount, false);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
+++ b/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTodayCommand;
@@ -53,6 +54,8 @@ public class PrescriptionListParser {
         switch (commandWord) {
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);
         case ListTodayCommand.COMMAND_WORD:

--- a/src/test/data/JsonSerializablePrescriptionListTest/typicalPrescriptionList.json
+++ b/src/test/data/JsonSerializablePrescriptionListTest/typicalPrescriptionList.json
@@ -10,7 +10,7 @@
     "totalStock" : "100",
     "consumptionCount" : "0",
     "isCompleted" : false,
-    "note" : "Take after food"
+    "note" : "Take before food"
   }, {
     "name" : "Propranolol",
     "dosage" : "4",

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -22,6 +22,7 @@ import seedu.address.model.Model;
 import seedu.address.model.PrescriptionList;
 import seedu.address.model.prescription.NameContainsKeywordsPredicate;
 import seedu.address.model.prescription.Prescription;
+import seedu.address.testutil.EditPrescriptionDescriptorBuilder;
 
 /**
  * Contains helper methods for testing commands.
@@ -41,8 +42,10 @@ public class CommandTestUtil {
     public static final String VALID_EXPIRY_DATE_ASPIRIN = "12/12/2024";
     public static final String VALID_EXPIRY_DATE_PROPRANOLOL = "22/07/2024";
     public static final String VALID_STOCK_ASPIRIN = "100";
+    public static final String VALID_CONSUMPTION_ASPIRIN = "1";
+    public static final String VALID_CONSUMPTION_PROPRANOLOL = "2";
     public static final String VALID_STOCK_PROPRANOLOL = "500";
-    public static final String VALID_NOTE_ASPIRIN = "Take after food";
+    public static final String VALID_NOTE_ASPIRIN = "Take before food";
     public static final String VALID_NOTE_PROPRANOLOL = "Take after food";
     // public static final String VALID_TAG_HUSBAND = "husband";
     // public static final String VALID_TAG_FRIEND = "friend";
@@ -80,19 +83,21 @@ public class CommandTestUtil {
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
-    /*
-    public static final EditCommand.EditPersonDescriptor DESC_AMY;
-    public static final EditCommand.EditPersonDescriptor DESC_BOB;
+    public static final EditCommand.EditPrescriptionDescriptor DESC_ASPIRIN;
+    public static final EditCommand.EditPrescriptionDescriptor DESC_PROPRANOLOL;
 
     static {
-        DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
-            .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-            .withTags(VALID_TAG_FRIEND).build();
-        DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
-            .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        DESC_ASPIRIN = new EditPrescriptionDescriptorBuilder().withName(VALID_NAME_ASPIRIN)
+            .withDosage(VALID_DOSAGE_ASPIRIN).withFrequency(VALID_FREQUENCY_ASPIRIN)
+            .withStartDate(VALID_START_DATE_ASPIRIN).withEndDate(VALID_END_DATE_ASPIRIN)
+            .withExpiryDate(VALID_EXPIRY_DATE_ASPIRIN).withTotalStock(VALID_STOCK_ASPIRIN)
+            .withConsumptionCount(VALID_CONSUMPTION_ASPIRIN).withNote(VALID_NOTE_ASPIRIN).build();
+        DESC_PROPRANOLOL = new EditPrescriptionDescriptorBuilder().withName(VALID_NAME_PROPRANOLOL)
+                .withDosage(VALID_DOSAGE_PROPRANOLOL).withFrequency(VALID_FREQUENCY_PROPRANOLOL)
+                .withStartDate(VALID_START_DATE_PROPRANOLOL).withEndDate(VALID_END_DATE_PROPRANOLOL)
+                .withExpiryDate(VALID_EXPIRY_DATE_PROPRANOLOL).withTotalStock(VALID_STOCK_PROPRANOLOL)
+                .withConsumptionCount(VALID_CONSUMPTION_PROPRANOLOL).withNote(VALID_NOTE_PROPRANOLOL).build();
     }
-    */
 
     /**
      * Executes the given {@code command}, confirms that <br>

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,11 +1,22 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_ASPIRIN;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DOSAGE_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FREQUENCY_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPrescriptionAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRESCRIPTION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PRESCRIPTION;
 import static seedu.address.testutil.TypicalPrescriptions.getTypicalPrescriptionList;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditCommand.EditPrescriptionDescriptor;
 import seedu.address.model.Model;
@@ -25,11 +36,140 @@ public class EditCommandTest {
         EditPrescriptionDescriptor descriptor = new EditPrescriptionDescriptorBuilder(editedPrescription).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PRESCRIPTION, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PRESCRIPTION_SUCCESS, Messages.format(editedPrescription));
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PRESCRIPTION_SUCCESS,
+                Messages.format(editedPrescription));
 
         Model expectedModel = new ModelManager(new PrescriptionList(model.getPrescriptionList()), new UserPrefs());
         expectedModel.setPrescription(model.getFilteredPrescriptionList().get(0), editedPrescription);
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        Index indexLastPrescription = Index.fromOneBased(model.getFilteredPrescriptionList().size());
+        Prescription lastPrescription = model.getFilteredPrescriptionList().get(indexLastPrescription.getZeroBased());
+
+        PrescriptionBuilder prescriptionInList = new PrescriptionBuilder(lastPrescription);
+        Prescription editedPrescription = prescriptionInList.withName(VALID_NAME_PROPRANOLOL)
+                .withDosage(VALID_DOSAGE_PROPRANOLOL)
+                .withFrequency(VALID_FREQUENCY_PROPRANOLOL).build();
+
+        EditPrescriptionDescriptor descriptor = new EditPrescriptionDescriptorBuilder().withName(VALID_NAME_PROPRANOLOL)
+                .withDosage(VALID_DOSAGE_PROPRANOLOL).withFrequency(VALID_FREQUENCY_PROPRANOLOL).build();
+        EditCommand editCommand = new EditCommand(indexLastPrescription, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PRESCRIPTION_SUCCESS,
+                Messages.format(editedPrescription));
+
+        Model expectedModel = new ModelManager(new PrescriptionList(model.getPrescriptionList()), new UserPrefs());
+
+        expectedModel.setPrescription(lastPrescription, editedPrescription);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PRESCRIPTION, new EditPrescriptionDescriptor());
+        Prescription editedPrescription = model.getFilteredPrescriptionList()
+                .get(INDEX_FIRST_PRESCRIPTION.getZeroBased());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PRESCRIPTION_SUCCESS,
+                Messages.format(editedPrescription));
+
+        Model expectedModel = new ModelManager(new PrescriptionList(model.getPrescriptionList()), new UserPrefs());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showPrescriptionAtIndex(model, INDEX_FIRST_PRESCRIPTION);
+
+        Prescription prescriptionInFilteredList = model.getFilteredPrescriptionList()
+                .get(INDEX_FIRST_PRESCRIPTION.getZeroBased());
+        Prescription editedPrescription = new PrescriptionBuilder(prescriptionInFilteredList)
+                .withName("Paracetamol").build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PRESCRIPTION,
+                new EditPrescriptionDescriptorBuilder().withName("Paracetamol").build());
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PRESCRIPTION_SUCCESS,
+                Messages.format(editedPrescription));
+
+        Model expectedModel = new ModelManager(new PrescriptionList(model.getPrescriptionList()), new UserPrefs());
+        expectedModel.setPrescription(model.getFilteredPrescriptionList().get(0), editedPrescription);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicatePrescriptionUnfilteredList_failure() {
+        Prescription firstPrescription = model.getFilteredPrescriptionList()
+                .get(INDEX_FIRST_PRESCRIPTION.getZeroBased());
+        EditPrescriptionDescriptor descriptor = new EditPrescriptionDescriptorBuilder(firstPrescription).build();
+        EditCommand editCommand = new EditCommand(INDEX_SECOND_PRESCRIPTION, descriptor);
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PRESCRIPTION);
+    }
+
+    @Test
+    public void execute_duplicatePersonFilteredList_failure() {
+        showPrescriptionAtIndex(model, INDEX_FIRST_PRESCRIPTION);
+
+        // edit prescription in filtered list into a duplicate in prescription list
+        Prescription prescriptionInList = model.getPrescriptionList().getPrescriptionList()
+                .get(INDEX_SECOND_PRESCRIPTION.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PRESCRIPTION,
+                new EditPrescriptionDescriptorBuilder(prescriptionInList).build());
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PRESCRIPTION);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPrescriptionList().size() + 1);
+        EditPrescriptionDescriptor descriptor = new EditPrescriptionDescriptorBuilder()
+                .withName(VALID_NAME_PROPRANOLOL).build();
+        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of prescription list
+     */
+    @Test
+    public void execute_invalidPersonIndexFilteredList_failure() {
+        showPrescriptionAtIndex(model, INDEX_FIRST_PRESCRIPTION);
+        Index outOfBoundIndex = INDEX_SECOND_PRESCRIPTION;
+        // ensures that outOfBoundIndex is still in bounds of prescription list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getPrescriptionList().getPrescriptionList().size());
+
+        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+                new EditPrescriptionDescriptorBuilder().withName(VALID_NAME_PROPRANOLOL).build());
+
+        assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PRESCRIPTION_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PRESCRIPTION, DESC_ASPIRIN);
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ListCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PRESCRIPTION, DESC_ASPIRIN)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PRESCRIPTION, DESC_PROPRANOLOL)));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,0 +1,35 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRESCRIPTION;
+import static seedu.address.testutil.TypicalPrescriptions.getTypicalPrescriptionList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditCommand.EditPrescriptionDescriptor;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.PrescriptionList;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.prescription.Prescription;
+import seedu.address.testutil.EditPrescriptionDescriptorBuilder;
+import seedu.address.testutil.PrescriptionBuilder;
+
+public class EditCommandTest {
+    private Model model = new ModelManager(getTypicalPrescriptionList(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Prescription editedPrescription = new PrescriptionBuilder().build();
+        EditPrescriptionDescriptor descriptor = new EditPrescriptionDescriptorBuilder(editedPrescription).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PRESCRIPTION, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PRESCRIPTION_SUCCESS, Messages.format(editedPrescription));
+
+        Model expectedModel = new ModelManager(new PrescriptionList(model.getPrescriptionList()), new UserPrefs());
+        expectedModel.setPrescription(model.getFilteredPrescriptionList().get(0), editedPrescription);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditPrescriptionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPrescriptionDescriptorTest.java
@@ -1,9 +1,18 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_ASPIRIN;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONSUMPTION_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DOSAGE_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EXPIRY_DATE_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_FREQUENCY_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NOTE_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE_PROPRANOLOL;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STOCK_PROPRANOLOL;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,35 +44,43 @@ public class EditPrescriptionDescriptorTest {
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different dosage -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withDosage(VALID_DOSAGE_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withDosage(VALID_DOSAGE_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different frequency -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withFrequency(VALID_FREQUENCY_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withFrequency(VALID_FREQUENCY_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different start date -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withStartDate(VALID_START_DATE_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withStartDate(VALID_START_DATE_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different end date -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withEndDate(VALID_END_DATE_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withEndDate(VALID_END_DATE_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different expiry date -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withExpiryDate(VALID_EXPIRY_DATE_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withExpiryDate(VALID_EXPIRY_DATE_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different total stock -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withTotalStock(VALID_STOCK_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withTotalStock(VALID_STOCK_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         //different consumption count -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withConsumptionCount(VALID_CONSUMPTION_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withConsumptionCount(VALID_CONSUMPTION_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
 
         // different note -> returns false
-        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withNote(VALID_NOTE_PROPRANOLOL).build();
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withNote(VALID_NOTE_PROPRANOLOL).build();
         assertFalse(DESC_ASPIRIN.equals(editedAspirin));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditPrescriptionDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPrescriptionDescriptorTest.java
@@ -1,0 +1,69 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.EditCommand.EditPrescriptionDescriptor;
+import seedu.address.testutil.EditPrescriptionDescriptorBuilder;
+
+public class EditPrescriptionDescriptorTest {
+    @Test
+    public void equals() {
+        // same values -> returns true
+        EditPrescriptionDescriptor descriptorWithSameValues = new EditPrescriptionDescriptor(DESC_ASPIRIN);
+        assertTrue(DESC_ASPIRIN.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_ASPIRIN.equals(DESC_ASPIRIN));
+
+        // null -> returns false
+        assertFalse(DESC_ASPIRIN.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_ASPIRIN.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_ASPIRIN.equals(DESC_PROPRANOLOL));
+
+        // different name -> returns false
+        EditPrescriptionDescriptor editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN)
+                .withName(VALID_NAME_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different dosage -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withDosage(VALID_DOSAGE_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different frequency -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withFrequency(VALID_FREQUENCY_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different start date -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withStartDate(VALID_START_DATE_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different end date -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withEndDate(VALID_END_DATE_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different expiry date -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withExpiryDate(VALID_EXPIRY_DATE_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different total stock -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withTotalStock(VALID_STOCK_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        //different consumption count -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withConsumptionCount(VALID_CONSUMPTION_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+
+        // different note -> returns false
+        editedAspirin = new EditPrescriptionDescriptorBuilder(DESC_ASPIRIN).withNote(VALID_NOTE_PROPRANOLOL).build();
+        assertFalse(DESC_ASPIRIN.equals(editedAspirin));
+    }
+}

--- a/src/test/java/seedu/address/testutil/EditPrescriptionDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPrescriptionDescriptorBuilder.java
@@ -1,0 +1,119 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.EditCommand.EditPrescriptionDescriptor;
+import seedu.address.model.prescription.ConsumptionCount;
+import seedu.address.model.prescription.Date;
+import seedu.address.model.prescription.Dosage;
+import seedu.address.model.prescription.Frequency;
+import seedu.address.model.prescription.Name;
+import seedu.address.model.prescription.Note;
+import seedu.address.model.prescription.Prescription;
+import seedu.address.model.prescription.Stock;
+
+/**
+ * A utility class to help with building EditPrescriptionDescriptor objects.
+ */
+public class EditPrescriptionDescriptorBuilder {
+
+    private EditPrescriptionDescriptor descriptor;
+
+    public EditPrescriptionDescriptorBuilder() {
+        descriptor = new EditPrescriptionDescriptor();
+    }
+
+    public EditPrescriptionDescriptorBuilder(EditPrescriptionDescriptor descriptor) {
+        this.descriptor = new EditPrescriptionDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditPrescriptionDescriptor} with fields containing {@code prescription}'s details
+     */
+    public EditPrescriptionDescriptorBuilder(Prescription prescription) {
+        descriptor = new EditPrescriptionDescriptor();
+        descriptor.setName(prescription.getName());
+        descriptor.setDosage(prescription.getDosage());
+        descriptor.setFrequency(prescription.getFrequency());
+        descriptor.setStartDate(prescription.getStartDate());
+        descriptor.setEndDate(prescription.getEndDate());
+        descriptor.setExpiryDate(prescription.getExpiryDate());
+        descriptor.setTotalStock(prescription.getTotalStock());
+        descriptor.setConsumptionCount(prescription.getConsumptionCount());
+        descriptor.setNote(prescription.getNote());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withName(String name) {
+        descriptor.setName(new Name(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Dosage} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withDosage(String dosage) {
+        descriptor.setDosage(new Dosage(dosage));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Frequency} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withFrequency(String frequency) {
+        descriptor.setFrequency(new Frequency(frequency));
+        return this;
+    }
+
+    /**
+     * Sets the {@code StartDate} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withStartDate(String startDate) {
+        descriptor.setStartDate(new Date(startDate));
+        return this;
+    }
+
+    /**
+     * Sets the {@code EndDate} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withEndDate(String endDate) {
+        descriptor.setEndDate(new Date(endDate));
+        return this;
+    }
+
+    /**
+     * Sets the {@code ExpiryDate} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withExpiryDate(String expiryDate) {
+        descriptor.setExpiryDate(new Date(expiryDate));
+        return this;
+    }
+
+    /**
+     * Sets the {@code TotalStock} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withTotalStock(String totalStock) {
+        descriptor.setTotalStock(new Stock(totalStock));
+        return this;
+    }
+
+    /**
+     * Sets the {@code ConsumptionCount} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withConsumptionCount(String consumptionCount) {
+        descriptor.setConsumptionCount(new ConsumptionCount(consumptionCount, false));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Note} of the {@code EditPrescriptionDescriptor} that we are building.
+     */
+    public EditPrescriptionDescriptorBuilder withNote(String note) {
+        descriptor.setNote(new Note(note));
+        return this;
+    }
+
+    public EditPrescriptionDescriptor build() {
+        return descriptor;
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPrescriptions.java
+++ b/src/test/java/seedu/address/testutil/TypicalPrescriptions.java
@@ -20,7 +20,7 @@ public class TypicalPrescriptions {
         .withExpiryDate("12/12/2024")
         .withStock("100")
         .withConsumptionCount("0")
-        .withNote("Take after food")
+        .withNote("Take before food")
         .build();
 
     public static final Prescription PROPRANOLOL = new PrescriptionBuilder().withName("Propranolol")


### PR DESCRIPTION
This commit introduces a new `EditCommand` to allow users to modify the details of an existing prescription in the prescription list. Users can specify the index of the prescription to edit and provide updated values for various fields, such as name, dosage, frequency, start date, end date, expiry date, total stock, consumption count, and notes.

This new feature enhances the functionality of the application by enabling users to make necessary changes to prescription details, ensuring accurate and up-to-date medication records.
