### PR TITLE
Add exit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -11,9 +11,17 @@ public class ExitCommand extends Command {
 
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Exits application.\n"
+            + "Example: " + COMMAND_WORD;
+
     @Override
     public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof ExitCommand;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ExitCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ExitCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ExitPrescriptionCommand object
+ */
+public class ExitCommandParser implements Parser<ExitCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ExitPrescriptionCommand
+     * and returns a ExitPrescriptionCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ExitCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ExitCommand.MESSAGE_USAGE));
+        }
+
+        return new ExitCommand();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
+++ b/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
@@ -11,11 +10,14 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTodayCommand;
 import seedu.address.logic.commands.TakeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+
 
 
 /**
@@ -64,6 +66,10 @@ public class PrescriptionListParser {
             return new TakeCommandParser().parse(arguments);
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommandParser().parse(arguments);
+
+
         default:
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/test/java/seedu/address/logic/parser/ExitCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ExitCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.ExitCommand;
+
+public class ExitCommandParserTest {
+    private ExitCommandParser parser = new ExitCommandParser();
+
+    @Test
+    public void parse_emptyPreamble_success() {
+        assertParseSuccess(parser, "", new ExitCommand());
+    }
+
+    @Test
+    public void parse_preambleWhitespace_success() {
+        assertParseSuccess(parser, " ", new ExitCommand());
+    }
+
+    @Test
+    public void parse_extraValues_failure() {
+        // Random values
+        assertParseFailure(parser, "ABCDEFGH",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ExitCommand.MESSAGE_USAGE));
+
+        // Random prefixes
+        assertParseFailure(parser, "mn/ABCD d/2",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, ExitCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Lets add an exit command to exit BayMeds with a command.

As the user is a fast typist, this will 
* improve the user's efficiency when using BayMeds
* remove the need to manually click the exit button
