### PR TITLE
Add logic to ensure correct date sequence

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
@@ -16,7 +15,6 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.prescription.IsValidDatesPredicate;
 import seedu.address.model.prescription.Prescription;

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXPIRY_DATE;
@@ -10,10 +11,14 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_STOCK;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
+import seedu.address.model.prescription.IsValidDatesPredicate;
 import seedu.address.model.prescription.Prescription;
 
 /**
@@ -48,6 +53,9 @@ public class AddCommand extends Command {
     public static final String MESSAGE_DUPLICATE_PRESCRIPTION = "This prescription already "
             + "exists in the prescription list.";
 
+    public static final String MESSAGE_INVALID_DATES = "Start date must be before end date, "
+            + "and end date must be before expiry date.";
+
     private final Prescription toAdd;
 
     /**
@@ -64,6 +72,12 @@ public class AddCommand extends Command {
 
         if (model.hasPrescription(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PRESCRIPTION);
+        }
+
+        Predicate<Prescription> isValidDates = new IsValidDatesPredicate();
+
+        if (!isValidDates.test(toAdd)) {
+            throw new CommandException(MESSAGE_INVALID_DATES);
         }
 
         model.addPrescription(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.AddCommand.MESSAGE_INVALID_DATES;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CONSUMPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DOSAGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
@@ -15,6 +16,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PRESCRIPTIONS;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
@@ -26,6 +28,7 @@ import seedu.address.model.prescription.ConsumptionCount;
 import seedu.address.model.prescription.Date;
 import seedu.address.model.prescription.Dosage;
 import seedu.address.model.prescription.Frequency;
+import seedu.address.model.prescription.IsValidDatesPredicate;
 import seedu.address.model.prescription.Name;
 import seedu.address.model.prescription.Note;
 import seedu.address.model.prescription.Prescription;
@@ -86,6 +89,12 @@ public class EditCommand extends Command {
 
         if (!prescriptionToEdit.isSamePrescription(editedPrescription) && model.hasPrescription(editedPrescription)) {
             throw new CommandException(MESSAGE_DUPLICATE_PRESCRIPTION);
+        }
+
+        Predicate<Prescription> isValidDates = new IsValidDatesPredicate();
+
+        if (!isValidDates.test(editedPrescription)) {
+            throw new CommandException(MESSAGE_INVALID_DATES);
         }
 
         model.setPrescription(prescriptionToEdit, editedPrescription);

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -11,6 +11,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_STOCK;
 
 // import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -18,6 +19,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.prescription.Date;
 import seedu.address.model.prescription.Dosage;
 import seedu.address.model.prescription.Frequency;
+import seedu.address.model.prescription.IsValidDatesPredicate;
 import seedu.address.model.prescription.Name;
 import seedu.address.model.prescription.Note;
 import seedu.address.model.prescription.Prescription;

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TOTAL_STOCK;
 
 // import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -19,7 +18,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.prescription.Date;
 import seedu.address.model.prescription.Dosage;
 import seedu.address.model.prescription.Frequency;
-import seedu.address.model.prescription.IsValidDatesPredicate;
 import seedu.address.model.prescription.Name;
 import seedu.address.model.prescription.Note;
 import seedu.address.model.prescription.Prescription;

--- a/src/main/java/seedu/address/model/prescription/IsValidDatesPredicate.java
+++ b/src/main/java/seedu/address/model/prescription/IsValidDatesPredicate.java
@@ -1,0 +1,19 @@
+package seedu.address.model.prescription;
+
+import java.time.LocalDate;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Prescription}'s {@code Date} is valid.
+ */
+public class IsValidDatesPredicate implements Predicate<Prescription> {
+    @Override
+    public boolean test(Prescription prescription) {
+        LocalDate startDate = prescription.getStartDate().getDate();
+        LocalDate endDate = prescription.getEndDate().getDate();
+        LocalDate expiryDate = prescription.getExpiryDate().getDate();
+
+        return startDate.isBefore(endDate) && endDate.isBefore(expiryDate);
+
+    }
+}

--- a/src/main/resources/view/MainWindowPrescription.fxml
+++ b/src/main/resources/view/MainWindowPrescription.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="Baymeds" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>


### PR DESCRIPTION
This commit introduces validation logic to ensure that dates are entered correctly when adding or editing prescriptions. Specifically, it enforces that the start date must be before the end date and the expiry date must be after the end date. This validation enhances the data integrity and accuracy of prescription records.
