### PR TITLE
V1.3 GUI

### DIFF
--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -12,8 +12,8 @@ import seedu.address.commons.util.ToStringBuilder;
  */
 public class GuiSettings implements Serializable {
 
-    private static final double DEFAULT_HEIGHT = 600;
-    private static final double DEFAULT_WIDTH = 740;
+    private static final double DEFAULT_HEIGHT = 830;
+    private static final double DEFAULT_WIDTH = 1350;
 
     private final double windowWidth;
     private final double windowHeight;

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -23,7 +23,22 @@ public class SampleDataUtil {
         return new Prescription[] {
             new Prescription(new Name("Aspirin"), new Dosage("1"), new Frequency("Daily"),
                             new Date("01/08/2023"), new Date("25/12/2023"), new Date("01/12/2024"),
-                            new Stock("100"), new Note("Test note")),
+                            new Stock("100"), new Note("Take before food")),
+            new Prescription(new Name("Propranolol"), new Dosage("4"), new Frequency("Daily"),
+                            new Date("01/08/2023"), new Date("20/01/2024"), new Date("02/07/2026"),
+                            new Stock("500"), new Note("Take after food")),
+            new Prescription(new Name("Ergotamine Tartrate"), new Dosage("1"), new Frequency("Weekly"),
+                            new Date("01/10/2023"), new Date("10/11/2025"), new Date("02/11/2026"),
+                            new Stock("50"), new Note("May cause drowsiness")),
+            new Prescription(new Name("Naproxen Sodium"), new Dosage("2"), new Frequency("Weekly"),
+                            new Date("01/10/2023"), new Date("01/11/2023"), new Date("02/11/2026"),
+                            new Stock("50"), new Note("Take before food")),
+            new Prescription(new Name("Zomig Rapimelt"), new Dosage("1"), new Frequency("Weekly"),
+                            new Date("01/10/2023"), new Date("01/11/2023"), new Date("12/06/2026"),
+                            new Stock("20"), new Note("Allow to dissolve under tongue")),
+            new Prescription(new Name("Omeprazole"), new Dosage("2"), new Frequency("Daily"),
+                            new Date("01/10/2023"), new Date("01/11/2024"), new Date("02/11/2026"),
+                            new Stock("200"), new Note("Take before food")),
         };
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -4,11 +4,14 @@ import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
+import javafx.scene.transform.Scale;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -121,6 +124,18 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+
+        scaleScreen();
+    }
+
+    private void scaleScreen() {
+        Rectangle2D screen = Screen.getPrimary().getBounds();
+        double screenScale = screen.getHeight() / 1080;
+        Scale scale = new Scale(screenScale, screenScale);
+        scale.setPivotX(screen.getWidth() / 2);
+        scale.setPivotY(screen.getHeight() / 2);
+        primaryStage.getScene().getRoot().getTransforms().setAll(scale);
+        primaryStage.centerOnScreen();
     }
 
     /**
@@ -129,6 +144,7 @@ public class MainWindow extends UiPart<Stage> {
     private void setWindowDefaultSize(GuiSettings guiSettings) {
         primaryStage.setHeight(guiSettings.getWindowHeight());
         primaryStage.setWidth(guiSettings.getWindowWidth());
+
         if (guiSettings.getWindowCoordinates() != null) {
             primaryStage.setX(guiSettings.getWindowCoordinates().getX());
             primaryStage.setY(guiSettings.getWindowCoordinates().getY());

--- a/src/main/java/seedu/address/ui/PrescriptionCard.java
+++ b/src/main/java/seedu/address/ui/PrescriptionCard.java
@@ -56,14 +56,34 @@ public class PrescriptionCard extends UiPart<Region> {
         super(FXML);
         this.prescription = prescription;
         id.setText(displayedIndex + ". ");
+
         name.setText(prescription.getName().toString());
-        dosage.setText(prescription.getDosage().toString());
-        frequency.setText(prescription.getFrequency().toString());
+
+        if (prescription.getDosage().isPresent()) {
+            dosage.setText(prescription.getDosage().get().toString());
+        }
+
+        if (prescription.getFrequency().isPresent()) {
+            frequency.setText(prescription.getFrequency().get().toString());
+        }
+
         startDate.setText(prescription.getStartDate().toString());
-        endDate.setText(prescription.getEndDate().toString());
-        expiryDate.setText(prescription.getExpiryDate().toString());
-        totalStock.setText(prescription.getTotalStock().toString());
-        note.setText(prescription.getNote().toString());
+
+        if (prescription.getEndDate().isPresent()) {
+            endDate.setText(prescription.getEndDate().get().toString());
+        }
+
+        if (prescription.getExpiryDate().isPresent()) {
+            expiryDate.setText(prescription.getExpiryDate().get().toString());
+        }
+
+        if (prescription.getTotalStock().isPresent()) {
+            totalStock.setText(prescription.getTotalStock().get().toString());
+        }
+
+        if (prescription.getNote().isPresent()) {
+            note.setText(prescription.getNote().get().toString());
+        }
 
         setCompletionStatus(prescription);
         // prescription.getTags().stream()
@@ -80,7 +100,7 @@ public class PrescriptionCard extends UiPart<Region> {
         } else {
             consumptionCount.setText(String.format("Uncompleted %s/%s",
                 prescription.getConsumptionCount().getConsumptionCount(),
-                prescription.getDosage()));
+                prescription.getDosage().get().toString()));
             consumptionCount.getStyleClass().add("consumption-status-red");
         }
     }

--- a/src/main/java/seedu/address/ui/PrescriptionCard.java
+++ b/src/main/java/seedu/address/ui/PrescriptionCard.java
@@ -61,28 +61,40 @@ public class PrescriptionCard extends UiPart<Region> {
 
         if (prescription.getDosage().isPresent()) {
             dosage.setText(prescription.getDosage().get().toString());
+        } else {
+            dosage.setText("");
         }
 
         if (prescription.getFrequency().isPresent()) {
             frequency.setText(prescription.getFrequency().get().toString());
+        } else {
+            frequency.setText("");
         }
 
         startDate.setText(prescription.getStartDate().toString());
 
         if (prescription.getEndDate().isPresent()) {
             endDate.setText(prescription.getEndDate().get().toString());
+        } else {
+            endDate.setText("");
         }
 
         if (prescription.getExpiryDate().isPresent()) {
             expiryDate.setText(prescription.getExpiryDate().get().toString());
+        } else {
+            expiryDate.setText("");
         }
 
         if (prescription.getTotalStock().isPresent()) {
             totalStock.setText(prescription.getTotalStock().get().toString());
+        } else {
+            totalStock.setText("");
         }
 
         if (prescription.getNote().isPresent()) {
             note.setText(prescription.getNote().get().toString());
+        } else {
+            note.setText("");
         }
 
         setCompletionStatus(prescription);

--- a/src/main/java/seedu/address/ui/PrescriptionCard.java
+++ b/src/main/java/seedu/address/ui/PrescriptionCard.java
@@ -49,22 +49,6 @@ public class PrescriptionCard extends UiPart<Region> {
     @FXML
     private Label note;
 
-    private String dosageHeader = "Dosage: ";
-
-    private String frequencyHeader = "Frequency: ";
-
-    private String startDateHeader = "Start date: ";
-
-    private String endDateHeader = "End date: ";
-
-    private String expiryDateHeader = "Expiry date: ";
-
-    private String totalStockHeader = "Total stock: ";
-
-    private String consumptionCountHeader = "Consumption count: ";
-
-    private String noteHeader = "Note: ";
-
     /**
      * Creates a {@code PrescriptionCode} with the given {@code Prescription} and index to display.
      */
@@ -73,17 +57,31 @@ public class PrescriptionCard extends UiPart<Region> {
         this.prescription = prescription;
         id.setText(displayedIndex + ". ");
         name.setText(prescription.getName().toString());
-        dosage.setText(dosageHeader + prescription.getDosage().toString());
-        frequency.setText(frequencyHeader + prescription.getFrequency().toString());
-        startDate.setText(startDateHeader + prescription.getStartDate().toString());
-        endDate.setText(endDateHeader + prescription.getEndDate().toString());
-        expiryDate.setText(expiryDateHeader + prescription.getExpiryDate().toString());
-        totalStock.setText(totalStockHeader + prescription.getTotalStock().toString());
-        consumptionCount.setText(consumptionCountHeader + prescription.getConsumptionCount().getConsumptionCount()
-                                + "/" + prescription.getDosage().toString());
-        note.setText(noteHeader + prescription.getNote().toString());
+        dosage.setText(prescription.getDosage().toString());
+        frequency.setText(prescription.getFrequency().toString());
+        startDate.setText(prescription.getStartDate().toString());
+        endDate.setText(prescription.getEndDate().toString());
+        expiryDate.setText(prescription.getExpiryDate().toString());
+        totalStock.setText(prescription.getTotalStock().toString());
+        note.setText(prescription.getNote().toString());
+
+        setCompletionStatus(prescription);
         // prescription.getTags().stream()
         //         .sorted(Comparator.comparing(tag -> tag.tagName))
         //         .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+    }
+
+    private void setCompletionStatus(Prescription prescription) {
+        consumptionCount.getStyleClass().clear();
+
+        if (prescription.getIsCompleted()) {
+            consumptionCount.setText("Completed");
+            consumptionCount.getStyleClass().add("consumption-status-green");
+        } else {
+            consumptionCount.setText(String.format("Uncompleted %s/%s",
+                prescription.getConsumptionCount().getConsumptionCount(),
+                prescription.getDosage()));
+            consumptionCount.getStyleClass().add("consumption-status-red");
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
 import javafx.scene.image.Image;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.StringUtil;
@@ -38,6 +39,7 @@ public class UiManager implements Ui {
 
         //Set the application icon.
         primaryStage.getIcons().add(getImage(ICON_APPLICATION));
+        primaryStage.initStyle(StageStyle.TRANSPARENT);
 
         try {
             mainWindow = new MainWindow(primaryStage, logic);

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane styleClass="stack-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane styleClass="modern-box-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
 </StackPane>
 

--- a/src/main/resources/view/CommandBox.fxml
+++ b/src/main/resources/view/CommandBox.fxml
@@ -3,7 +3,13 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.StackPane?>
 
+<?import javafx.geometry.Insets?>
+
 <StackPane styleClass="modern-box-pane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here..."/>
+  <TextField fx:id="commandTextField" onAction="#handleCommandEntered" promptText="Enter command here...">
+    <padding>
+      <Insets top="10" right="15" bottom="10" left="15" />
+    </padding>
+  </TextField>
 </StackPane>
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -1,6 +1,30 @@
+/* Extra styles for BayMeds */
+#mainWindowBackground {
+     -fx-background-color: #474C5F;
+     -fx-background-radius: 2em;
+}
+
+#mainWindowLabel {
+     -fx-font-size: 25pt;
+     -fx-font-family: "Segoe UI Semibold";
+     -fx-text-fill: #FBFCFC;
+     -fx-opacity: 1;
+}
+
+#rightWindowBackground {
+     -fx-background-color: derive(#989AAD, 20%);
+     -fx-background-radius: 0em 2em 2em 0em;
+}
+
+.modern-box-pane {
+     -fx-background-color: derive(#989AAD, 20%);
+     -fx-background-radius: 1em;
+}
+
+/* AB3 Styles */
 .background {
     -fx-background-color: derive(#1d1d1d, 20%);
-    background-color: #383838; /* Used in the default.html file */
+    background-color: #474C5F; /* Used in the default.html file */
 }
 
 .label {
@@ -87,24 +111,25 @@
     -fx-background-color: derive(#1d1d1d, 20%);
 }
 
-.list-view {
+#prescriptionListView {
     -fx-background-insets: 0;
     -fx-padding: 0;
-    -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-color: transparent;
 }
 
 .list-cell {
     -fx-label-padding: 0 0 0 0;
     -fx-graphic-text-gap : 0;
     -fx-padding: 0 0 0 0;
+    -fx-background-radius: 1em;
 }
 
 .list-cell:filled:even {
-    -fx-background-color: #3c3e3f;
+    -fx-background-color: transparent;
 }
 
 .list-cell:filled:odd {
-    -fx-background-color: #515658;
+    -fx-background-color: transparent;
 }
 
 .list-cell:filled:selected {
@@ -113,7 +138,7 @@
 
 .list-cell:filled:selected #cardPane {
     -fx-border-color: #3e7b91;
-    -fx-border-width: 1;
+    -fx-border-width: 0;
 }
 
 .list-cell .label {
@@ -143,14 +168,14 @@
 }
 
 .status-bar {
-    -fx-background-color: derive(#1d1d1d, 30%);
+    -fx-background-color: transparent;
 }
 
 .result-display {
     -fx-background-color: transparent;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: white;
+    -fx-text-fill: #ffffff;
 }
 
 .result-display .label {
@@ -194,6 +219,7 @@
 
 .menu-bar {
     -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-background-radius: 1em;
 }
 
 .menu-bar .label {
@@ -318,22 +344,22 @@
 }
 
 #commandTextField {
-    -fx-background-color: transparent #383838 transparent #383838;
+    -fx-background-color: transparent #989AAD transparent #989AAD;
     -fx-background-insets: 0;
-    -fx-border-color: #383838 #383838 #ffffff #383838;
     -fx-border-insets: 0;
     -fx-border-width: 1;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: white;
+    -fx-text-fill : #ffffff;
+    -fx-prompt-text-fill: #ffffff;
 }
 
-#filterField, #personListPanel, #personWebpage {
+#filterField, #prescriptionListPanel, #prescriptionWebpage {
     -fx-effect: innershadow(gaussian, black, 10, 0, 0, 0);
 }
 
 #resultDisplay .content {
-    -fx-background-color: transparent, #383838, transparent, #383838;
+    -fx-background-color: transparent, derive(#989AAD, 20%), transparent, derive(#989AAD, 20%);
     -fx-background-radius: 0;
 }
 

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -1,24 +1,44 @@
 /* Extra styles for BayMeds */
 #mainWindowBackground {
-     -fx-background-color: #474C5F;
+     -fx-background-color: #202124;
      -fx-background-radius: 2em;
+     -fx-effect: dropshadow(three-pass-box, derive(#202124, -20%), 10, 0, 0, 0);
+     -fx-background-insets: 5;
 }
 
 #mainWindowLabel {
      -fx-font-size: 25pt;
      -fx-font-family: "Segoe UI Semibold";
-     -fx-text-fill: #FBFCFC;
+     -fx-text-fill: #F2E8E3;
      -fx-opacity: 1;
 }
 
 #rightWindowBackground {
-     -fx-background-color: derive(#989AAD, 20%);
+     -fx-background-color: #3C4042;
      -fx-background-radius: 0em 2em 2em 0em;
 }
 
 .modern-box-pane {
-     -fx-background-color: derive(#989AAD, 20%);
+     -fx-background-color: #424242;
      -fx-background-radius: 1em;
+     -fx-effect: dropshadow(gaussian, #ADD8E625, 20, 0, 0, 0);
+     -fx-background-insets: 5;
+}
+
+.consumption-status-green {
+     -fx-background-color: #2E7D32;
+     -fx-background-radius: 1em;
+     -fx-font-size: 11pt;
+     -fx-text-fill: #F2E8E3;
+     -fx-padding: 5;
+}
+
+.consumption-status-red {
+     -fx-background-color: #D32F2F;
+     -fx-background-radius: 1em;
+     -fx-font-size: 11pt;
+     -fx-text-fill: #F2E8E3;
+     -fx-padding: 5;
 }
 
 /* AB3 Styles */
@@ -120,15 +140,14 @@
 .list-cell {
     -fx-label-padding: 0 0 0 0;
     -fx-graphic-text-gap : 0;
-    -fx-padding: 0 0 0 0;
+    -fx-padding: 15;
+    -fx-background-insets: 15;
+    -fx-background-color: #424242;
     -fx-background-radius: 1em;
+    -fx-effect: dropshadow(gaussian, #ADD8E650, 15, 0, 0, 0);
 }
 
-.list-cell:filled:even {
-    -fx-background-color: transparent;
-}
-
-.list-cell:filled:odd {
+.list-cell:empty {
     -fx-background-color: transparent;
 }
 
@@ -142,19 +161,27 @@
 }
 
 .list-cell .label {
-    -fx-text-fill: white;
+    -fx-text-fill: #F2E8E3;
 }
 
 .cell_big_label {
     -fx-font-family: "Segoe UI Semibold";
     -fx-font-size: 16px;
-    -fx-text-fill: #010504;
+    -fx-text-fill: #F2E8E3;
 }
+
+.cell_small_header {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 13px;
+    -fx-font-weight: bold;
+    -fx-text-fill: #F2E8E3;
+}
+
 
 .cell_small_label {
     -fx-font-family: "Segoe UI";
     -fx-font-size: 13px;
-    -fx-text-fill: #010504;
+    -fx-text-fill: #F2E8E3;
 }
 
 .stack-pane {
@@ -175,7 +202,7 @@
     -fx-background-color: transparent;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: #ffffff;
+    -fx-text-fill: #F2E8E3;
 }
 
 .result-display .label {
@@ -184,7 +211,7 @@
 
 .status-bar .label {
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: #F2E8E3;
     -fx-padding: 4px;
     -fx-pref-height: 30px;
 }
@@ -210,22 +237,23 @@
 }
 
 .context-menu {
-    -fx-background-color: derive(#1d1d1d, 50%);
+    -fx-background-color: #424242;
 }
 
 .context-menu .label {
-    -fx-text-fill: white;
+    -fx-text-fill: #F2E8E3;
 }
 
 .menu-bar {
-    -fx-background-color: derive(#1d1d1d, 20%);
-    -fx-background-radius: 1em;
+    -fx-padding: 0 0 0 20;
+    -fx-background-color: #202124;
+    -fx-background-radius: 2em 0em 0em 0em;
 }
 
 .menu-bar .label {
     -fx-font-size: 14pt;
     -fx-font-family: "Segoe UI Light";
-    -fx-text-fill: white;
+    -fx-text-fill: #F2E8E3;
     -fx-opacity: 0.9;
 }
 
@@ -239,24 +267,16 @@
  * http://pixelduke.wordpress.com/2012/10/23/jmetro-windows-8-controls-on-java/
  */
 .button {
-    -fx-padding: 5 22 5 22;
-    -fx-border-color: #e2e2e2;
-    -fx-border-width: 2;
+    -fx-padding: 3 10 3 10;
     -fx-background-radius: 0;
-    -fx-background-color: #1d1d1d;
-    -fx-font-family: "Segoe UI", Helvetica, Arial, sans-serif;
-    -fx-font-size: 11pt;
-    -fx-text-fill: #d8d8d8;
-    -fx-background-insets: 0 0 0 0, 0, 1, 2;
+    -fx-background-color: #3C4042;
+    -fx-font-family: "Segoe UI Bold";
+    -fx-font-size: 14pt;
+    -fx-text-fill: #F2E8E3;
 }
 
 .button:hover {
-    -fx-background-color: #3a3a3a;
-}
-
-.button:pressed, .button:default:hover:pressed {
-  -fx-background-color: white;
-  -fx-text-fill: #1d1d1d;
+    -fx-background-color: #0096C9;
 }
 
 .button:focused {
@@ -309,6 +329,8 @@
 
 .scroll-bar {
     -fx-background-color: derive(#1d1d1d, 20%);
+    -fx-unit-increment: 0.1;
+    -fx-block-increment: 0.1;
 }
 
 .scroll-bar .thumb {
@@ -344,14 +366,13 @@
 }
 
 #commandTextField {
-    -fx-background-color: transparent #989AAD transparent #989AAD;
+    -fx-background-color: transparent;
     -fx-background-insets: 0;
     -fx-border-insets: 0;
-    -fx-border-width: 1;
     -fx-font-family: "Segoe UI Light";
     -fx-font-size: 13pt;
-    -fx-text-fill : #ffffff;
-    -fx-prompt-text-fill: #ffffff;
+    -fx-text-fill : #F2E8E3;
+    -fx-prompt-text-fill: #F2E8E3;
 }
 
 #filterField, #prescriptionListPanel, #prescriptionWebpage {
@@ -359,7 +380,7 @@
 }
 
 #resultDisplay .content {
-    -fx-background-color: transparent, derive(#989AAD, 20%), transparent, derive(#989AAD, 20%);
+    -fx-background-color: #424242;
     -fx-background-radius: 0;
 }
 

--- a/src/main/resources/view/MainWindowPrescription.fxml
+++ b/src/main/resources/view/MainWindowPrescription.fxml
@@ -11,50 +11,96 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.HBox?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-         title="Baymeds" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+         title="BayMeds v.2103" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
   <scene>
-    <Scene>
+    <Scene fill="transparent">
       <stylesheets>
         <URL value="@DarkTheme.css" />
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
-          <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </Menu>
-        </MenuBar>
+      <BorderPane fx:id="mainWindowBackground">
+        <left>
+          <Pane prefHeight="830.0" prefWidth="650.0" BorderPane.alignment="CENTER">
+            <padding>
+              <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
+            </padding>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+            <children>
+              <HBox layoutX="45.0" layoutY="60.0" alignment="CENTER" spacing="10">
+                <Label text="BayMeds" fx:id="mainWindowLabel" />
+                <MenuBar fx:id="menuBar">
+                  <Menu mnemonicParsing="false" text="File">
+                    <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+                  </Menu>
+                  <Menu mnemonicParsing="false" text="Help">
+                    <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+                  </Menu>
+                </MenuBar>
+              </HBox>
+              <StackPane
+                fx:id="commandBoxPlaceholder"
+                styleClass="modern-box-pane"
+                layoutX="45.0"
+                layoutY="145.0"
+                prefHeight="34.0"
+                prefWidth="560.0"
+              >
+                <padding>
+                  <Insets top="5" right="10" bottom="5" left="10" />
+                </padding>
+              </StackPane>
+              <StackPane
+                fx:id="resultDisplayPlaceholder"
+                styleClass="modern-box-pane"
+                layoutX="45.0"
+                layoutY="220.0"
+                minHeight="100"
+                prefHeight="480.0"
+                prefWidth="560.0"
+              >
+                <padding>
+                  <Insets top="5" right="10" bottom="5" left="10" />
+                </padding>
+              </StackPane>
+              <StackPane fx:id="statusbarPlaceholder" layoutX="45.0" layoutY="700.0" />
+            </children>
+          </Pane>
+        </left>
+        <center>
+          <Pane prefHeight="830.0" prefWidth="700.0" BorderPane.alignment="CENTER" fx:id="rightWindowBackground">
+            <padding>
+              <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
+            </padding>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
-
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="prescriptionListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
-
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-      </VBox>
+            <children>
+              <VBox
+                fx:id="prescriptionList"
+                styleClass="modern-box-pane"
+                layoutX="45.0"
+                layoutY="60.0"
+                minWidth="340"
+                prefWidth="595"
+                prefHeight="690"
+                VBox.vgrow="ALWAYS"
+              >
+                <padding>
+                  <Insets top="10" right="10" bottom="10" left="10" />
+                </padding>
+                <StackPane fx:id="prescriptionListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+              </VBox>
+            </children>
+          </Pane>
+        </center>
+      </BorderPane>
     </Scene>
   </scene>
 </fx:root>

--- a/src/main/resources/view/MainWindowPrescription.fxml
+++ b/src/main/resources/view/MainWindowPrescription.fxml
@@ -15,6 +15,7 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.control.Button?>
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
          title="BayMeds v.2103" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
@@ -28,77 +29,84 @@
       </stylesheets>
 
       <BorderPane fx:id="mainWindowBackground">
-        <left>
-          <Pane prefHeight="830.0" prefWidth="650.0" BorderPane.alignment="CENTER">
-            <padding>
-              <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
-            </padding>
+        <padding>
+          <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+        </padding>
 
-            <children>
-              <HBox layoutX="45.0" layoutY="60.0" alignment="CENTER" spacing="10">
-                <Label text="BayMeds" fx:id="mainWindowLabel" />
-                <MenuBar fx:id="menuBar">
-                  <Menu mnemonicParsing="false" text="File">
-                    <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-                  </Menu>
-                  <Menu mnemonicParsing="false" text="Help">
-                    <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-                  </Menu>
-                </MenuBar>
-              </HBox>
-              <StackPane
-                fx:id="commandBoxPlaceholder"
-                styleClass="modern-box-pane"
-                layoutX="45.0"
-                layoutY="145.0"
-                prefHeight="34.0"
-                prefWidth="560.0"
-              >
-                <padding>
-                  <Insets top="5" right="10" bottom="5" left="10" />
-                </padding>
-              </StackPane>
-              <StackPane
-                fx:id="resultDisplayPlaceholder"
-                styleClass="modern-box-pane"
-                layoutX="45.0"
-                layoutY="220.0"
-                minHeight="100"
-                prefHeight="480.0"
-                prefWidth="560.0"
-              >
-                <padding>
-                  <Insets top="5" right="10" bottom="5" left="10" />
-                </padding>
-              </StackPane>
-              <StackPane fx:id="statusbarPlaceholder" layoutX="45.0" layoutY="700.0" />
-            </children>
-          </Pane>
+        <left>
+          <VBox>
+            <MenuBar fx:id="menuBar">
+              <Menu mnemonicParsing="false" text="File">
+                <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+              </Menu>
+              <Menu mnemonicParsing="false" text="Help">
+                <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+              </Menu>
+            </MenuBar>
+            <Pane prefHeight="830.0" prefWidth="650.0" BorderPane.alignment="CENTER">
+              <padding>
+                <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
+              </padding>
+
+              <children>
+                <Label text="BayMeds" fx:id="mainWindowLabel" layoutX="50.0" layoutY="60.0" />
+                <StackPane
+                  fx:id="commandBoxPlaceholder"
+                  styleClass="modern-box-pane"
+                  layoutX="45.0"
+                  layoutY="145.0"
+                  prefHeight="34.0"
+                  prefWidth="560.0"
+                />
+                <StackPane
+                  fx:id="resultDisplayPlaceholder"
+                  styleClass="modern-box-pane"
+                  layoutX="45.0"
+                  layoutY="220.0"
+                  minHeight="100"
+                  prefHeight="480.0"
+                  prefWidth="560.0"
+                />
+                <StackPane fx:id="statusbarPlaceholder" layoutX="45.0" layoutY="700.0" />
+              </children>
+            </Pane>
+          </VBox>
         </left>
         <center>
-          <Pane prefHeight="830.0" prefWidth="700.0" BorderPane.alignment="CENTER" fx:id="rightWindowBackground">
-            <padding>
-              <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
-            </padding>
+          <VBox fx:id="rightWindowBackground">
+            <BorderPane>
+              <padding>
+                <Insets right="20.0"/>
+              </padding>
 
-            <children>
-              <VBox
-                fx:id="prescriptionList"
-                styleClass="modern-box-pane"
-                layoutX="45.0"
-                layoutY="60.0"
-                minWidth="340"
-                prefWidth="595"
-                prefHeight="690"
-                VBox.vgrow="ALWAYS"
-              >
-                <padding>
-                  <Insets top="10" right="10" bottom="10" left="10" />
-                </padding>
-                <StackPane fx:id="prescriptionListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-              </VBox>
-            </children>
-          </Pane>
+              <right>
+                <Button mnemonicParsing="false" text="X" onAction="#handleExit"/>
+              </right>
+            </BorderPane>
+            <Pane prefHeight="830.0" prefWidth="700.0" BorderPane.alignment="CENTER">
+              <padding>
+                <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
+              </padding>
+
+              <children>
+                <VBox
+                  fx:id="prescriptionList"
+                  style="-fx-background-color: transparent"
+                  layoutX="45.0"
+                  layoutY="60.0"
+                  minWidth="340"
+                  prefWidth="595"
+                  prefHeight="690"
+                  VBox.vgrow="ALWAYS"
+                >
+                  <padding>
+                    <Insets top="10" right="10" bottom="10" left="10" />
+                  </padding>
+                  <StackPane fx:id="prescriptionListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                </VBox>
+              </children>
+            </Pane>
+          </VBox>
         </center>
       </BorderPane>
     </Scene>

--- a/src/main/resources/view/PrescriptionListCard.fxml
+++ b/src/main/resources/view/PrescriptionListCard.fxml
@@ -9,6 +9,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.layout.BorderPane?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
@@ -18,24 +19,59 @@
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
-          <minWidth>
-            <!-- Ensures that the label text is never truncated -->
-            <Region fx:constant="USE_PREF_SIZE" />
-          </minWidth>
-        </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-      </HBox>
-      <!--FlowPane fx:id="tags" /-->
-      <Label fx:id="dosage" styleClass="cell_small_label" text="\$dosage" />
-      <Label fx:id="frequency" styleClass="cell_small_label" text="\$frequency" />
-      <Label fx:id="startDate" styleClass="cell_small_label" text="\$startDate" />
-      <Label fx:id="endDate" styleClass="cell_small_label" text="\$endDate" />
-      <Label fx:id="expiryDate" styleClass="cell_small_label" text="\$expiryDate" />
-      <Label fx:id="totalStock" styleClass="cell_small_label" text="\$totalStock" />
-      <Label fx:id="consumptionCount" styleClass="cell_small_label" text="\$consumptionCount" />
-      <Label fx:id="note" styleClass="cell_small_label" text="\$note" />
+
+      <BorderPane>
+        <left>
+          <HBox spacing="5" alignment="CENTER_LEFT">
+            <Label fx:id="id" styleClass="cell_big_label">
+              <minWidth>
+                <!-- Ensures that the label text is never truncated -->
+                <Region fx:constant="USE_PREF_SIZE" />
+              </minWidth>
+            </Label>
+            <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+          </HBox>
+        </left>
+        <right>
+          <Label fx:id="consumptionCount" text="\$consumptionCount" styleClass="consumption-status-red" />
+        </right>
+      </BorderPane>
+      <GridPane hgap="20" vgap="20">
+        <padding>
+          <Insets top="10" right="10" bottom="10" left="10" />
+        </padding>
+
+        <children>
+          <VBox>
+            <Label fx:id="dosageHeader" styleClass="cell_small_header" text="Dosage" />
+            <Label fx:id="dosage" styleClass="cell_small_label" text="\$dosage" />
+          </VBox>
+          <VBox GridPane.rowIndex="1">
+            <Label fx:id="frequencyHeader" styleClass="cell_small_header" text="Frequency" />
+            <Label fx:id="frequency" styleClass="cell_small_label" text="\$frequency" />
+          </VBox>
+          <VBox GridPane.rowIndex="2">
+            <Label fx:id="totalStockHeader" styleClass="cell_small_header" text="Total Stock" />
+            <Label fx:id="totalStock" styleClass="cell_small_label" text="\$totalStock" />
+          </VBox>
+          <VBox GridPane.columnIndex="1" GridPane.rowIndex="0">
+            <Label fx:id="startDateHeader" styleClass="cell_small_header" text="Start Date" />
+            <Label fx:id="startDate" styleClass="cell_small_label" text="\$startDate" />
+          </VBox>
+          <VBox GridPane.columnIndex="1" GridPane.rowIndex="1">
+            <Label fx:id="endDateHeader" styleClass="cell_small_header" text="End Date" />
+            <Label fx:id="endDate" styleClass="cell_small_label" text="\$endDate" />
+          </VBox>
+          <VBox GridPane.columnIndex="1" GridPane.rowIndex="2">
+            <Label fx:id="Header" styleClass="cell_small_header" text="Expiry Date" />
+            <Label fx:id="expiryDate" styleClass="cell_small_label" text="\$expiryDate" />
+          </VBox>
+          <VBox GridPane.columnIndex="2">
+            <Label fx:id="noteHeader" styleClass="cell_small_header" text="Note" />
+            <Label fx:id="note" styleClass="cell_small_label" text="\$note" />
+          </VBox>
+        </children>
+      </GridPane>
     </VBox>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,17 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
+<?import javafx.geometry.Insets?>
+
 <StackPane fx:id="placeHolder" styleClass="modern-box-pane" xmlns="http://javafx.com/javafx/17"
-    xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+           xmlns:fx="http://javafx.com/fxml/1">
+  <TextArea
+    fx:id="resultDisplay"
+    editable="false"
+    styleClass="result-display"
+  >
+    <padding>
+      <Insets top="5" right="10" bottom="5" left="10" />
+    </padding>
+  </TextArea>
 </StackPane>

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/17"
+<StackPane fx:id="placeHolder" styleClass="modern-box-pane" xmlns="http://javafx.com/javafx/17"
     xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
 </StackPane>

--- a/src/main/resources/view/dummy.fxml
+++ b/src/main/resources/view/dummy.fxml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuBar?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+
+<?import javafx.scene.layout.BorderPane?>
+<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
+         title="Baymeds" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+  <icons>
+    <Image url="@/images/address_book_32.png" />
+  </icons>
+  <scene>
+    <Scene>
+      <stylesheets>
+        <URL value="@DarkTheme.css" />
+        <URL value="@Extensions.css" />
+      </stylesheets>
+
+      <VBox>
+        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
+          <Menu mnemonicParsing="false" text="File">
+            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
+          </Menu>
+          <Menu mnemonicParsing="false" text="Help">
+            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
+          </Menu>
+        </MenuBar>
+
+        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+          <padding>
+            <Insets top="5" right="10" bottom="5" left="10" />
+          </padding>
+        </StackPane>
+
+        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+                   minHeight="100" prefHeight="100" maxHeight="100">
+          <padding>
+            <Insets top="5" right="10" bottom="5" left="10" />
+          </padding>
+        </StackPane>
+
+        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+          <padding>
+            <Insets top="10" right="10" bottom="10" left="10" />
+          </padding>
+          <StackPane fx:id="prescriptionListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+        </VBox>
+
+        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+      </VBox>
+    </Scene>
+  </scene>
+</fx:root>


### PR DESCRIPTION
I have refactored the GUI into the following.

![gui](https://github.com/AY2324S1-CS2103T-T15-2/tp/assets/119654395/a6127042-6381-4012-9d76-5d6104c0bf8e)

There are two motivating factors for this:

1. Our commands are long. It would be good to have a tall output box to show the example syntaxes. So instead of having a long unreadable line of `Example: add mn/Aspirin d/1 f/Daily sd/01/08/2023 ed/25/12/2023 exd/01/01/2024 ts/100 n/Test note`, we can break the parameters down into lines and display on the LHS. **These line breaks have not been implemented yet.**
2. To allow for better readability of the prescription, I have broken the list down to the RHS and made it (hopefully) cleaner.

The consumption will automatically update to red or green depending on the status.

I have also added more sample data into `SampleData.util` to test the scroll bar.

**I need yall to help pull this into your local and try run the GUI and test. JavaFX doesn't inherently support responsive UI that adjust properly to different screen sizes so I tried my best to work around it already.** As an intended feature, you cannot resize or move the application at all. Everything is scaled to the centered and resized to your screen size upon start up.