### PR TITLE
Add untake command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UntakeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UntakeCommand.java
@@ -15,13 +15,13 @@ import seedu.address.model.prescription.SameNamePredicate;
 import seedu.address.model.prescription.Stock;
 
 /**
- * Represents a command to take a specified number of doses of a prescription.
+ * Represents a command to untake a specified number of doses of a prescription.
  */
-public class TakeCommand extends Command {
-    public static final String COMMAND_WORD = "take";
+public class UntakeCommand extends Command {
+    public static final String COMMAND_WORD = "untake";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Takes a specified number of doses of a prescription.\n"
+            + ": Untakes a specified number of doses of a prescription.\n"
             + "Parameters: "
             + PREFIX_NAME + "medication_name "
             + PREFIX_CONSUMPTION + "number_of_doses \n"
@@ -29,26 +29,25 @@ public class TakeCommand extends Command {
             + PREFIX_NAME + "Aspirin "
             + PREFIX_CONSUMPTION + "2";
 
-    public static final String MESSAGE_SUCCESS = "Doses taken from: %1$s.";
-    public static final String MESSAGE_PRESCRIPTION_NOT_FOUND = "The specified prescription does not exist.";
-    public static final String MESSAGE_INSUFFICIENT_STOCK = "There is insufficient stock for this prescription.";
+    public static final String MESSAGE_SUCCESS = "Doses untaken from: %1$s";
+    public static final String MESSAGE_INSUFFICIENT_CONSUMPTION = "Cannot untake more than what you have consumed.";
 
     private final Name prescriptionName;
-    private final int dosesToTake;
+    private final int dosesToUntake;
 
     /**
-     * Creates a TakePrescriptionCommand to take the specified number of doses from a prescription.
+     * Creates an UntakePrescriptionCommand to untake the specified number of doses from a prescription.
      *
      * @param prescriptionName Name of the prescription.
-     * @param dosesToTake      Number of doses to take.
+     * @param dosesToTake      Number of doses to untake.
      */
-    public TakeCommand(Name prescriptionName, int dosesToTake) {
+    public UntakeCommand(Name prescriptionName, int dosesToTake) {
         this.prescriptionName = prescriptionName;
-        this.dosesToTake = dosesToTake;
+        this.dosesToUntake = dosesToTake;
     }
 
     /**
-     * Executes the TakePrescriptionCommand to take the specified doses from the prescription.
+     * Executes the UntakePrescriptionCommand to untake the specified doses from the prescription.
      *
      * @param model The model of the prescription list.
      * @return A CommandResult with the result of the execution.
@@ -62,17 +61,17 @@ public class TakeCommand extends Command {
         Prescription prescription = model.getPrescriptionByName(prescriptionName);
         Optional<Stock> totalStock = prescription.getTotalStock();
 
-        if (totalStock.isPresent() && (Integer.parseInt(totalStock.get().toString()) - dosesToTake < 0)) {
-            throw new CommandException(MESSAGE_INSUFFICIENT_STOCK);
+        if (Integer.parseInt(prescription.getConsumptionCount().getConsumptionCount()) - dosesToUntake < 0) {
+            throw new CommandException(MESSAGE_INSUFFICIENT_CONSUMPTION);
         }
 
         if (totalStock.isPresent()) {
-            totalStock.get().decrementCount(dosesToTake);
+            totalStock.get().incrementCount(dosesToUntake);
         }
-        prescription.getConsumptionCount().incrementCount(dosesToTake);
+        prescription.getConsumptionCount().decrementCount(dosesToUntake);
 
         if (prescription.getDosage().isPresent()
-            && Integer.parseInt(prescription.getConsumptionCount().toString())
+                && Integer.parseInt(prescription.getConsumptionCount().toString())
                 >= Integer.parseInt(prescription.getDosage().get().toString())) {
             prescription.setIsCompleted(true);
         } else {
@@ -91,12 +90,12 @@ public class TakeCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof TakeCommand)) {
+        if (!(other instanceof UntakeCommand)) {
             return false;
         }
 
-        TakeCommand otherCommand = (TakeCommand) other;
+        UntakeCommand otherCommand = (UntakeCommand) other;
         return prescriptionName.equals(otherCommand.prescriptionName)
-                && dosesToTake == otherCommand.dosesToTake;
+                && dosesToUntake == otherCommand.dosesToUntake;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
+++ b/src/main/java/seedu/address/logic/parser/PrescriptionListParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListTodayCommand;
 import seedu.address.logic.commands.TakeCommand;
+import seedu.address.logic.commands.UntakeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 
@@ -64,6 +65,8 @@ public class PrescriptionListParser {
             return new ListTodayCommandParser().parse(arguments);
         case TakeCommand.COMMAND_WORD:
             return new TakeCommandParser().parse(arguments);
+        case UntakeCommand.COMMAND_WORD:
+            return new UntakeCommandParser().parse(arguments);
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
         case ExitCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/UntakeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UntakeCommandParser.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONSUMPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.UntakeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.prescription.ConsumptionCount;
+import seedu.address.model.prescription.Name;
+
+/**
+ * Parses input arguments and creates a new UntakePrescriptionCommand object
+ */
+public class UntakeCommandParser implements Parser<UntakeCommand> {
+
+    /**
+     * Parses the given arguments to create an UntakePrescriptionCommand.
+     *
+     * @param args User input representing the command.
+     * @return An UntakePrescriptionCommand for untaking a specified number of doses from a prescription.
+     * @throws ParseException If the user input does not conform to the expected format.
+     */
+    @Override
+    public UntakeCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_CONSUMPTION);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_CONSUMPTION)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    UntakeCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_CONSUMPTION);
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        ConsumptionCount consumptionCount = ParserUtil
+                .parseConsumptionCount(argMultimap.getValue(PREFIX_CONSUMPTION).get());
+        int dosesToUntake = Integer.parseInt(consumptionCount.getConsumptionCount());
+
+        return new UntakeCommand(name, dosesToUntake);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/UntakeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UntakeCommandTest.java
@@ -1,0 +1,120 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.UntakeCommand.MESSAGE_INSUFFICIENT_CONSUMPTION;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PRESCRIPTION;
+import static seedu.address.testutil.TypicalPrescriptions.getTypicalPrescriptionList;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.PrescriptionList;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.prescription.Name;
+import seedu.address.model.prescription.Prescription;
+import seedu.address.model.prescription.SameNamePredicate;
+import seedu.address.testutil.PrescriptionBuilder;
+
+public class UntakeCommandTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalPrescriptionList(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_validDosesToUntake_success() throws CommandException {
+        PrescriptionList prescriptionList = new PrescriptionList();
+        Prescription prescriptionToUntake = new PrescriptionBuilder()
+                .withConsumptionCount("100")
+                .withStock("100")
+                .build();
+        prescriptionList.addPrescription(prescriptionToUntake);
+        Model model = new ModelManager(prescriptionList, new UserPrefs());
+        Model expectedModel = new ModelManager(model.getPrescriptionList(),
+                new UserPrefs());
+
+        int initialStock = Integer.parseInt(prescriptionToUntake.getTotalStock().get().toString());
+        int dosesToUntake = 1; //Valid number of doses
+
+        UntakeCommand untakePrescriptionCommand = new UntakeCommand(
+                prescriptionToUntake.getName(), dosesToUntake);
+
+        String expectedMessage = String.format(UntakeCommand.MESSAGE_SUCCESS,
+                prescriptionToUntake.getName());
+        Prescription expectedPrescription = expectedModel.getPrescriptionByName(prescriptionToUntake.getName());
+        expectedPrescription.getTotalStock().get().incrementCount(dosesToUntake);
+        expectedPrescription.getConsumptionCount().decrementCount(dosesToUntake);
+        expectedModel.updateFilteredPrescriptionList(new SameNamePredicate(prescriptionToUntake.getName()));
+
+        int newStock = Integer.parseInt(expectedModel.getPrescriptionByName(prescriptionToUntake.getName())
+                .getTotalStock().get().toString());
+
+        assertCommandSuccess(untakePrescriptionCommand, model, expectedMessage, expectedModel);
+
+        assertEquals(initialStock + dosesToUntake, newStock);
+    }
+
+    @Test
+    public void execute_insufficientConsumption_throwsCommandException() throws CommandException {
+        Prescription prescriptionToUntake = model.getFilteredPrescriptionList()
+                .get(INDEX_FIRST_PRESCRIPTION.getZeroBased());
+
+        int initialConsumption = Integer.parseInt(prescriptionToUntake.getConsumptionCount().toString());
+        int dosesToUntake = initialConsumption + 1; // More than currently consumed
+
+        UntakeCommand untakePrescriptionCommand = new UntakeCommand(
+                prescriptionToUntake.getName(), dosesToUntake);
+
+        assertCommandFailure(untakePrescriptionCommand, model, MESSAGE_INSUFFICIENT_CONSUMPTION);
+
+        // Ensure that the consumption is not modified
+        int newConsumption = Integer.parseInt(model.getPrescriptionByName(prescriptionToUntake.getName())
+                .getConsumptionCount().toString());
+        assertEquals(initialConsumption, newConsumption);
+    }
+
+    @Test
+    public void execute_invalidPrescription_throwsCommandException() {
+        Prescription prescriptionToUntake = new PrescriptionBuilder().withName("Invalid Name").build();
+        int dosesToUntake = 1; // A valid number of doses
+
+        UntakeCommand untakePrescriptionCommand = new UntakeCommand(
+                prescriptionToUntake.getName(), dosesToUntake);
+
+        assertCommandFailure(untakePrescriptionCommand, model, TakeCommand.MESSAGE_PRESCRIPTION_NOT_FOUND);
+    }
+
+    @Test
+    public void equals() {
+        Name name1 = new Name("Aspirin");
+        Name name2 = new Name("Panadol");
+        int doses1 = 2;
+        int doses2 = 1;
+
+        UntakeCommand command1 = new UntakeCommand(name1, doses1);
+        UntakeCommand command2 = new UntakeCommand(name1, doses1);
+        UntakeCommand command3 = new UntakeCommand(name2, doses1);
+        UntakeCommand command4 = new UntakeCommand(name1, doses2);
+
+        // Same object
+        assertTrue(command1.equals(command1));
+
+        // Test for equality
+        assertTrue(command1.equals(command2)); // Same name and doses
+        assertTrue(command2.equals(command1)); // Test for symmetry
+        assertFalse(command1.equals(command3)); // Different names
+        assertFalse(command1.equals(command4)); // Different doses
+
+        // Test for non-equality
+        assertFalse(command1.equals(null)); // Null object
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UntakeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UntakeCommandParserTest.java
@@ -1,0 +1,82 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONSUMPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.UntakeCommand;
+import seedu.address.model.prescription.ConsumptionCount;
+import seedu.address.model.prescription.Name;
+
+
+public class UntakeCommandParserTest {
+
+    private UntakeCommandParser parser = new UntakeCommandParser();
+
+    @Test
+    public void parse_validArgs_success() {
+        // Valid arguments with a valid name and dosage
+        UntakeCommand expectedCommand = new UntakeCommand(new Name("Aspirin"), 2);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Aspirin "
+                + PREFIX_CONSUMPTION + "2", expectedCommand);
+    }
+
+    @Test
+    public void parse_notIntegerDosage_failure() {
+        // Invalid dosage (not an integer)
+        assertParseFailure(parser, " " + PREFIX_NAME + "Aspirin "
+                + PREFIX_CONSUMPTION + "abc", ConsumptionCount.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_negativeIntegerDosage_failure() {
+        // Invalid dosage (not an integer)
+        assertParseFailure(parser, " " + PREFIX_NAME + "Aspirin "
+                + PREFIX_CONSUMPTION + "-1", ConsumptionCount.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_emptyPreamble_failure() {
+        // Empty input
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UntakeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_whitespacePreamble_failure() {
+        // Whitespace input
+        assertParseFailure(parser, " ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UntakeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_missingName_failure() {
+        // Missing Name
+        assertParseFailure(parser, " " + PREFIX_CONSUMPTION + "2", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UntakeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_missingDosage_failure() {
+        // Missing dosage
+        assertParseFailure(parser, " " + PREFIX_NAME + "Aspirin", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                UntakeCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_extraValues_failure() {
+        // Random values
+        assertParseFailure(parser, "ABCDEFGH",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        UntakeCommand.MESSAGE_USAGE));
+
+        // Random prefixes
+        assertParseFailure(parser, "mn/ABCD d/2",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        UntakeCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
This commit addresses issue #71 . Users previously had no way to decrement the consumption count in case of errors or changes in dosage.

To provide a mechanism to correct consumption counts when necessary and improve flexibility for users. The UntakeCommand is introduced, enabling users to decrease the consumption count for a prescription. This approach allows users to maintain accurate consumption records and offers greater control over dosage adjustments.

Resolves: #71