### PR TITLE
Prevent Input of Numbers That Exceed Data Type Limits 

### DIFF
--- a/src/main/java/seedu/address/model/prescription/ConsumptionCount.java
+++ b/src/main/java/seedu/address/model/prescription/ConsumptionCount.java
@@ -7,8 +7,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class ConsumptionCount {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "ConsumptionCount should only contain numeric characters, and it should not be blank.";
+    public static final String MESSAGE_CONSTRAINTS = "ConsumptionCount should be a non-blank, "
+            + "positive integer with numeric characters only, "
+            + "and smaller than the maximum possible integer value (2,147,483,647).";
 
     public static final String VALIDATION_REGEX = "[0-9]+";
     private String consumptionCount;
@@ -57,7 +58,16 @@ public class ConsumptionCount {
      * Returns true if a given string is a valid dosage.
      */
     public static boolean isValidConsumptionCount(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        try {
+            int consumptionValue = Integer.parseInt(test);
+            return (consumptionValue >= 0) && (consumptionValue <= Integer.MAX_VALUE);
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/prescription/Dosage.java
+++ b/src/main/java/seedu/address/model/prescription/Dosage.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Dosage {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Dosages should only contain numeric characters, and it should not be blank.";
+    public static final String MESSAGE_CONSTRAINTS = "Dosages should be non-blank, "
+            + "positive integer with numeric characters only, "
+            + "and smaller than the maximum possible integer value (2,147,483,647).";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -35,7 +36,17 @@ public class Dosage {
      * Returns true if a given string is a valid dosage.
      */
     public static boolean isValidDosage(String test) {
-        return test.matches(VALIDATION_REGEX);
+
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        try {
+            int dosageValue = Integer.parseInt(test);
+            return (dosageValue >= 0) && (dosageValue <= Integer.MAX_VALUE);
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
 

--- a/src/main/java/seedu/address/model/prescription/Stock.java
+++ b/src/main/java/seedu/address/model/prescription/Stock.java
@@ -9,8 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Stock {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Stocks should only contain numeric characters, and it should not be blank.";
+    public static final String MESSAGE_CONSTRAINTS = "Stocks should be a non-blank, "
+            + "positive integer with numeric characters only, "
+            + "and smaller than the maximum possible integer value (2,147,483,647).";
 
     /*
      * The first character of the address must not be a whitespace,
@@ -35,7 +36,16 @@ public class Stock {
      * Returns true if a given string is a valid stock.
      */
     public static boolean isValidStock(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (!test.matches(VALIDATION_REGEX)) {
+            return false;
+        }
+
+        try {
+            int stockValue = Integer.parseInt(test);
+            return (stockValue >= 0) && (stockValue <= Integer.MAX_VALUE);
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     public void setFullStock(String fullStock) {

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -55,8 +55,6 @@ import seedu.address.model.prescription.Stock;
 import seedu.address.testutil.EditPrescriptionDescriptorBuilder;
 
 public class EditCommandParserTest {
-    private static final String MESSAGE_INVALID_FORMAT =
-            String.format(EditCommand.MESSAGE_USAGE, EditCommand.MESSAGE_USAGE);
     private EditCommandParser parser = new EditCommandParser();
 
     @Test

--- a/src/test/java/seedu/address/model/prescription/StockTest.java
+++ b/src/test/java/seedu/address/model/prescription/StockTest.java
@@ -29,6 +29,9 @@ public class StockTest {
         assertFalse(Stock.isValidStock(" ")); // spaces only
         assertFalse(Stock.isValidStock("^")); // non-alphanumeric characters
         assertFalse(Stock.isValidStock("a")); // alphabets
+        assertFalse((Stock.isValidStock("1.2"))); // decimal number
+        assertFalse((Stock.isValidStock("-1"))); // negative number
+        assertFalse((Stock.isValidStock("2147483648"))); // greater than max int value
 
         // valid stock
         assertTrue(Stock.isValidStock("1")); // single digit


### PR DESCRIPTION
This commit resolves the issue where users were able to input numbers that exceeded the limits of the data types used for processing. Such input could lead to a java.lang.NumberFormatException when processing, causing errors in the application.

- Changes have been made to the 'dosages,' 'frequency,' and 'take' functionalities to prevent users from inputting numbers that are too large.
- Now, when adding a prescription, input validation checks ensure that dosages, frequency, and take values are within the allowed data type limits.

This update enhances the stability and reliability of the application by preventing potential NumberFormatException errors caused by oversized numbers in user input.

Fixes #67