### PR TITLE
Update moving of prescriptions to completed list

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -37,9 +37,6 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of completed prescriptions */
     ObservableList<Prescription> getFilteredCompletedPrescriptionList();
 
-    /** Returns the flag indicating whether to display the completed list */
-    boolean getIsDisplayingCompletedList();
-
     /**
      * Returns the user prefs' prescription list file path.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -70,9 +70,13 @@ public class LogicManager implements Logic {
     public void checkAndMoveEndedPrescriptions() {
         PrescriptionList prescriptionListCopy = new PrescriptionList(model.getPrescriptionList());
         for (Prescription prescription : prescriptionListCopy.getPrescriptionList()) {
-            if (prescription.isEnded()) {
-                model.deletePrescription(prescription);
-            }
+            deleteAndMovePrescription(prescription);
+        }
+    }
+
+    private void deleteAndMovePrescription(Prescription prescription) {
+        if (prescription.isEnded()) {
+            model.deletePrescription(prescription);
             if (!model.hasCompletedPrescription(prescription)) {
                 model.addCompletedPrescription(prescription);
             }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -67,11 +67,13 @@ public class LogicManager implements Logic {
     /**
      * Deletes prescriptions that are past the end date and stores them in the completed prescription list.
      */
-    public void checkAndMoveEndedPrescriptions() throws IOException {
+    public void checkAndMoveEndedPrescriptions() {
         PrescriptionList prescriptionListCopy = new PrescriptionList(model.getPrescriptionList());
         for (Prescription prescription : prescriptionListCopy.getPrescriptionList()) {
             if (prescription.isEnded()) {
                 model.deletePrescription(prescription);
+            }
+            if (!model.hasCompletedPrescription(prescription)) {
                 model.addCompletedPrescription(prescription);
             }
         }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,7 +10,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.ListCompletedCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.PrescriptionListParser;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -34,7 +34,6 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final PrescriptionListParser prescriptionListParser;
-    private boolean isDisplayingCompletedList;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -43,7 +42,6 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         prescriptionListParser = new PrescriptionListParser();
-        this.isDisplayingCompletedList = false;
     }
 
     @Override
@@ -53,17 +51,8 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
         Command command = prescriptionListParser.parseCommand(commandText);
 
-        if (command instanceof ListCompletedCommand) {
-            // Handle the ListCompletedCommand
-            this.isDisplayingCompletedList = true;
-            checkAndMoveEndedPrescriptions();
-        } else {
-            // Handle other commands...
-            this.isDisplayingCompletedList = false;
-        }
-
         commandResult = command.execute(model);
-
+        checkAndMoveEndedPrescriptions();
         try {
             storage.savePrescriptionList(model.getPrescriptionList());
             storage.saveCompletedPrescriptionList(model.getCompletedPrescriptionList());
@@ -87,8 +76,6 @@ public class LogicManager implements Logic {
                 model.addCompletedPrescription(prescription);
             }
         }
-        storage.savePrescriptionList(model.getPrescriptionList());
-        storage.saveCompletedPrescriptionList(model.getCompletedPrescriptionList());
     }
 
     @Override
@@ -105,10 +92,6 @@ public class LogicManager implements Logic {
         return model.getFilteredCompletedPrescriptionList();
     }
 
-    @Override
-    public boolean getIsDisplayingCompletedList() {
-        return this.isDisplayingCompletedList;
-    }
     @Override
     public Path getPrescriptionListFilePath() {
         return model.getPrescriptionListFilePath();

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.io.TempDir;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.ListCompletedCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -97,13 +97,6 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void executeListCompletedCommand_successful() throws Exception {
-        String listCompletedCommand = ListCompletedCommand.COMMAND_WORD;
-        assertCommandSuccess(listCompletedCommand, ListCompletedCommand.MESSAGE_EMPTY_LIST, model);
-        assertTrue(logic.getIsDisplayingCompletedList());
-    }
-
-    @Test
     public void getFilteredPrescriptionList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPrescriptionList().remove(0));
     }


### PR DESCRIPTION
Previously the check to move prescriptions was only done if it is a listCompleted command, changed it such that it checks after every command so if a user adds a prescription that has an end date that is already past, it goes into the completed list right away.