### PR TITLE
Add Reminder window

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
@@ -63,6 +64,7 @@ public class HelpWindow extends UiPart<Stage> {
      *     </ul>
      */
     public void show() {
+        logger.log(Level.INFO, "show() called");
         logger.fine("Showing help page about the application.");
         getRoot().show();
         getRoot().centerOnScreen();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,6 +1,9 @@
 package seedu.address.ui;
 
 import java.io.IOException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javafx.event.ActionEvent;
@@ -38,6 +41,7 @@ public class MainWindow extends UiPart<Stage> {
     private PrescriptionListPanel prescriptionListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+    private ReminderWindow reminderWindow;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -70,6 +74,21 @@ public class MainWindow extends UiPart<Stage> {
         setAccelerators();
 
         helpWindow = new HelpWindow();
+        reminderWindow = new ReminderWindow();
+
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+        logger.log(Level.INFO, "Starting reminder thread...");
+        executor.scheduleAtFixedRate(() -> {
+            try {
+                // wait 10 seconds before checking for reminders
+                TimeUnit.SECONDS.sleep(10);
+                logger.log(Level.INFO, "Checking for reminders...");
+                //executeCommand("help");
+                handleHelp();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }, 0, 5, TimeUnit.SECONDS);
     }
 
     public Stage getPrimaryStage() {
@@ -161,10 +180,24 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleHelp() {
+        logger.log(Level.INFO, "handleHelp() called");
         if (!helpWindow.isShowing()) {
             helpWindow.show();
         } else {
             helpWindow.focus();
+        }
+        logger.log(Level.INFO, "handleHelp() ended");
+    }
+
+    /**
+     * Opens the reminder window or focuses on it if it's already opened.
+     */
+    @FXML
+    public void handleRemind() {
+        if (!reminderWindow.isShowing()) {
+            reminderWindow.show();
+        } else {
+            reminderWindow.focus();
         }
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,11 +1,12 @@
 package seedu.address.ui;
 
 import java.io.IOException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.geometry.Rectangle2D;
@@ -17,6 +18,7 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.transform.Scale;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
+import javafx.util.Duration;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
@@ -32,8 +34,8 @@ public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindowPrescription.fxml";
 
+    private static Timeline timer;
     private final Logger logger = LogsCenter.getLogger(getClass());
-
     private Stage primaryStage;
     private Logic logic;
 
@@ -42,7 +44,6 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private ReminderWindow reminderWindow;
-
     @FXML
     private StackPane commandBoxPlaceholder;
 
@@ -57,6 +58,7 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane statusbarPlaceholder;
+
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -76,19 +78,10 @@ public class MainWindow extends UiPart<Stage> {
         helpWindow = new HelpWindow();
         reminderWindow = new ReminderWindow();
 
-        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-        logger.log(Level.INFO, "Starting reminder thread...");
-        executor.scheduleAtFixedRate(() -> {
-            try {
-                // wait 10 seconds before checking for reminders
-                TimeUnit.SECONDS.sleep(10);
-                logger.log(Level.INFO, "Checking for reminders...");
-                //executeCommand("help");
-                handleHelp();
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }, 0, 5, TimeUnit.SECONDS);
+        timer = new Timeline(new KeyFrame(Duration.seconds(10), event -> {
+            handleRemind();
+        }));
+        timer.play();
     }
 
     public Stage getPrimaryStage() {
@@ -180,13 +173,11 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleHelp() {
-        logger.log(Level.INFO, "handleHelp() called");
         if (!helpWindow.isShowing()) {
             helpWindow.show();
         } else {
             helpWindow.focus();
         }
-        logger.log(Level.INFO, "handleHelp() ended");
     }
 
     /**
@@ -194,11 +185,16 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     public void handleRemind() {
-        if (!reminderWindow.isShowing()) {
-            reminderWindow.show();
-        } else {
-            reminderWindow.focus();
-        }
+        Platform.runLater(() -> {
+            logger.log(Level.INFO, "handleRemind() called");
+            if (!reminderWindow.isShowing()) {
+                reminderWindow.show();
+            } else {
+                reminderWindow.focus();
+            }
+            logger.log(Level.INFO, "handleRemind() ended");
+            timer.play();
+        });
     }
 
     void show() {

--- a/src/main/java/seedu/address/ui/ReminderWindow.java
+++ b/src/main/java/seedu/address/ui/ReminderWindow.java
@@ -1,0 +1,84 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
+import seedu.address.commons.core.LogsCenter;
+
+/**
+ * Controller for a Reminder page
+ */
+public class ReminderWindow extends UiPart<Stage> {
+
+    public static final String REMINDER_MESSAGE = "Reminder to eat medication";
+
+    private static final Logger logger = LogsCenter.getLogger(ReminderWindow.class);
+    private static final String FXML = "ReminderWindow.fxml";
+
+    @FXML
+    private Label reminderMessage;
+
+    /**
+     * Creates a new ReminderWindow.
+     *
+     * @param root Stage to use as the root of the ReminderWindow.
+     */
+    public ReminderWindow(Stage root) {
+        super(FXML, root);
+        //reminderMessage.setText(REMINDER_MESSAGE);
+    }
+
+    /**
+     * Creates a new ReminderWindow.
+     */
+    public ReminderWindow() {
+        this(new Stage());
+    }
+
+    /**
+     * Shows the Reminder window.
+     * @throws IllegalStateException
+     *     <ul>
+     *         <li>
+     *             if this method is called on a thread other than the JavaFX Application Thread.
+     *         </li>
+     *         <li>
+     *             if this method is called during animation or layout processing.
+     *         </li>
+     *         <li>
+     *             if this method is called on the primary stage.
+     *         </li>
+     *         <li>
+     *             if {@code dialogStage} is already showing.
+     *         </li>
+     *     </ul>
+     */
+    public void show() {
+        logger.fine("Showing Reminder window.");
+        getRoot().show();
+        getRoot().centerOnScreen();
+    }
+
+    /**
+     * Returns true if the Reminder window is currently being shown.
+     */
+    public boolean isShowing() {
+        return getRoot().isShowing();
+    }
+
+    /**
+     * Hides the Reminder window.
+     */
+    public void hide() {
+        getRoot().hide();
+    }
+
+    /**
+     * Focuses on the Reminder window.
+     */
+    public void focus() {
+        getRoot().requestFocus();
+    }
+}

--- a/src/main/java/seedu/address/ui/ReminderWindow.java
+++ b/src/main/java/seedu/address/ui/ReminderWindow.java
@@ -4,6 +4,7 @@ import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -12,7 +13,8 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class ReminderWindow extends UiPart<Stage> {
 
-    public static final String REMINDER_MESSAGE = "Reminder to eat medication";
+    public static final String REMINDER_MESSAGE = "Reminder to eat medication, use listToday command to view today's "
+            + "prescriptions.";
 
     private static final Logger logger = LogsCenter.getLogger(ReminderWindow.class);
     private static final String FXML = "ReminderWindow.fxml";
@@ -27,7 +29,12 @@ public class ReminderWindow extends UiPart<Stage> {
      */
     public ReminderWindow(Stage root) {
         super(FXML, root);
-        //reminderMessage.setText(REMINDER_MESSAGE);
+        root.initModality(Modality.APPLICATION_MODAL);
+        root.setMinWidth(300);
+        root.setMinHeight(50);
+        root.setResizable(false);
+        root.showAndWait();
+        reminderMessage.setText(REMINDER_MESSAGE);
     }
 
     /**

--- a/src/main/resources/view/ReminderWindow.css
+++ b/src/main/resources/view/ReminderWindow.css
@@ -1,0 +1,19 @@
+#copyButton, #reminderMessage {
+    -fx-text-fill: white;
+}
+
+#copyButton {
+    -fx-background-color: dimgray;
+}
+
+#copyButton:hover {
+    -fx-background-color: gray;
+}
+
+#copyButton:armed {
+    -fx-background-color: darkgray;
+}
+
+#reminderMessageContainer {
+    -fx-background-color: derive(#1d1d1d, 20%);
+}

--- a/src/main/resources/view/ReminderWindow.fxml
+++ b/src/main/resources/view/ReminderWindow.fxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.stage.Stage?>
+
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+    <icons>
+        <Image url="@/images/help_icon.png" />
+    </icons>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@ReminderWindow.css" />
+            </stylesheets>
+
+            <HBox alignment="CENTER" fx:id="reminderMessageContainer">
+                <children>
+                    <Label fx:id="reminderMessage" text="Label">
+                        <HBox.margin>
+                            <Insets right="5.0" />
+                        </HBox.margin>
+                    </Label>
+                </children>
+                <opaqueInsets>
+                    <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+                </opaqueInsets>
+                <padding>
+                    <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+                </padding>
+            </HBox>
+        </Scene>
+    </scene>
+</fx:root>

--- a/src/main/resources/view/ReminderWindow.fxml
+++ b/src/main/resources/view/ReminderWindow.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Reminder" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/help_icon.png" />
     </icons>
@@ -21,7 +21,7 @@
 
             <HBox alignment="CENTER" fx:id="reminderMessageContainer">
                 <children>
-                    <Label fx:id="reminderMessage" text="Label">
+                    <Label fx:id="reminderMessage" text="Reminder to eat medication, use listToday command to view today's prescriptions.">
                         <HBox.margin>
                             <Insets right="5.0" />
                         </HBox.margin>


### PR DESCRIPTION
Lets try to have help window pop up, the rest should be easier to implement.

I suspect it might be because I am calling handleHelp() in a separate thread.

In Toolkit.java https://github.com/jgneff/javafx-graphics/blob/master/src/javafx.graphics/classes/com/sun/javafx/tk/Toolkit.java

```
public void checkFxUserThread() {
        // Throw exception if not on FX user thread
        if (!isFxUserThread()) {
            throw new IllegalStateException("Not on FX application thread; currentThread = "
                    + Thread.currentThread().getName());
        }
    }
```

I think Timer, TimerTask and related classes create a new thread.

1. How do we schedule a function to be called (after a timed interval) in the same thread.
2. Any other alternatives to implementing this?

