### PR TITLE
Fix UI bugs for long strings in PrescriptionCard

### DIFF
--- a/src/main/resources/view/PrescriptionListCard.fxml
+++ b/src/main/resources/view/PrescriptionListCard.fxml
@@ -22,14 +22,14 @@
 
       <BorderPane>
         <left>
-          <HBox spacing="5" alignment="CENTER_LEFT">
+          <HBox spacing="5" alignment="CENTER_LEFT" prefWidth="250">
             <Label fx:id="id" styleClass="cell_big_label">
               <minWidth>
                 <!-- Ensures that the label text is never truncated -->
                 <Region fx:constant="USE_PREF_SIZE" />
               </minWidth>
             </Label>
-            <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+            <Label fx:id="name" text="\$first" wrapText="true" styleClass="cell_big_label" />
           </HBox>
         </left>
         <right>
@@ -66,9 +66,9 @@
             <Label fx:id="expiryDateHeader" styleClass="cell_small_header" text="Expiry Date" />
             <Label fx:id="expiryDate" styleClass="cell_small_label" text="\$expiryDate" />
           </VBox>
-          <VBox GridPane.columnIndex="2">
+          <VBox GridPane.columnIndex="2" prefWidth="275">
             <Label fx:id="noteHeader" styleClass="cell_small_header" text="Note" />
-            <Label fx:id="note" styleClass="cell_small_label" text="\$note" />
+            <Label fx:id="note" styleClass="cell_small_label" text="\$note" wrapText="true" />
           </VBox>
         </children>
       </GridPane>


### PR DESCRIPTION
Texts for medication name and notes now hard-wrap at the following boundaries:
![image](https://github.com/AY2324S1-CS2103T-T15-2/tp/assets/119654395/ad4df938-7ece-445c-81a6-2bbd6be3d7dd)

The boundaries were chosen WRT to the display for listToday.
A conscious decision was made to wrap the texts instead of the truncating with "...."

**This does not fix the overflow errors from parseInt resulting from too large numbers for stock and dosage.**